### PR TITLE
Remove debug analysis output in Positions manager

### DIFF
--- a/app/services/positions/manager.rb
+++ b/app/services/positions/manager.rb
@@ -36,7 +36,6 @@ module Positions
 
           position['ltp'] = estimate_ltp(position)
           analysis = Orders::Analyzer.call(position)
-          pp analysis # Debugging line, can be removed later
           Orders::Manager.call(position, analysis)
         end
       end


### PR DESCRIPTION
## Summary
- remove leftover debugging `pp` call from positions manager cache iteration

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: dhanhq-0.2.3 requires ruby version >= 3.3.0, which is incompatible with the current version, 3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb12fc810832ab6ee6b0adbcf531e