### PR TITLE
feat: refresh Dhan positions periodically

### DIFF
--- a/app/services/dhan/ws/feed_listener.rb
+++ b/app/services/dhan/ws/feed_listener.rb
@@ -34,6 +34,11 @@ module Dhan
           ws.on(:open) do
             pp '[WS] ▶ Connected'
             subscribe(ws)
+
+            EM.add_periodic_timer(Positions::ActiveCache::REFRESH_SEC) do
+              Positions::ActiveCache.refresh!
+              subscribe(ws)
+            end
           end
 
           ws.on(:message) do |event|


### PR DESCRIPTION
## Summary
- refresh ActiveCache and resubscribe over websocket periodically

## Testing
- `rubocop app/services/dhan/ws/feed_listener.rb` *(fails: plugins require `plugins` instead of `require`)*
- `rspec` *(fails: Could not find rails-8.0.1, pg-1.5.9, puma-6.5.0, ...)*


------
https://chatgpt.com/codex/tasks/task_e_68bbb11b66bc832a98107faefa1cee3d