### PR TITLE
Set actual EOD time in Positions::Manager

### DIFF
--- a/app/services/positions/manager.rb
+++ b/app/services/positions/manager.rb
@@ -7,8 +7,8 @@ module Positions
   # - Falls back to DhanHQ API if cache is empty.
   # - Skips execution during EOD hours.
   class Manager < ApplicationService
-    EOD_HOUR = 23
-    EOD_MIN  = 15
+    EOD_HOUR = 15
+    EOD_MIN  = 25
 
     # Main entry point to trigger exit logic
     #


### PR DESCRIPTION
## Summary
- avoid after-hours execution by setting EOD_HOUR to 15
- set EOD_MIN to 25 to align with NSE close

## Testing
- `bundle exec rspec` *(fails: command not found)*
- `bundle install` *(fails: dhanhq-0.2.3 requires ruby >= 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb12c74b0832a945e610efe51da3f