### PR TITLE
Fix deep ITM/OTM comparisons and add boundary tests

### DIFF
--- a/app/services/option/chain_analyzer.rb
+++ b/app/services/option/chain_analyzer.rb
@@ -580,9 +580,9 @@ module Option
       return false unless atm_strike
 
       if signal_type == :ce
-        strike_price > atm_strike * 1.2 # Deep ITM for calls
+        strike_price < atm_strike * 0.8 # Deep ITM for calls
       elsif signal_type == :pe
-        strike_price < atm_strike * 0.8 # Deep ITM for puts
+        strike_price > atm_strike * 1.2 # Deep ITM for puts
       end
     end
 
@@ -591,9 +591,9 @@ module Option
       return false unless atm_strike
 
       if signal_type == :ce
-        strike_price < atm_strike * 0.8 # Deep OTM for calls
+        strike_price > atm_strike * 1.2 # Deep OTM for calls
       elsif signal_type == :pe
-        strike_price > atm_strike * 1.2 # Deep OTM for puts
+        strike_price < atm_strike * 0.8 # Deep OTM for puts
       end
     end
 

--- a/spec/services/option/chain_analyzer_spec.rb
+++ b/spec/services/option/chain_analyzer_spec.rb
@@ -95,4 +95,59 @@ RSpec.describe Option::ChainAnalyzer, type: :service do
       expect(result).to eq(proceed: false, reason: 'Late entry, theta risk')
     end
   end
+
+  describe 'deep strike classification' do
+    let(:option_chain) { { oc: { 100 => {} }, last_price: 100 } }
+    let(:expiry) { Date.today.to_s }
+    let(:spot) { 100.0 }
+    let(:iv_rank) { 0.5 }
+
+    before do
+      allow(analyzer).to receive(:determine_atm_strike).and_return(100)
+    end
+
+    describe '#deep_itm_strike?' do
+      context 'for calls' do
+        it 'returns true when below 80% of ATM' do
+          expect(analyzer.send(:deep_itm_strike?, 79, :ce)).to be(true)
+        end
+
+        it 'returns false at 80% boundary' do
+          expect(analyzer.send(:deep_itm_strike?, 80, :ce)).to be(false)
+        end
+      end
+
+      context 'for puts' do
+        it 'returns true when above 120% of ATM' do
+          expect(analyzer.send(:deep_itm_strike?, 121, :pe)).to be(true)
+        end
+
+        it 'returns false at 120% boundary' do
+          expect(analyzer.send(:deep_itm_strike?, 120, :pe)).to be(false)
+        end
+      end
+    end
+
+    describe '#deep_otm_strike?' do
+      context 'for calls' do
+        it 'returns true when above 120% of ATM' do
+          expect(analyzer.send(:deep_otm_strike?, 121, :ce)).to be(true)
+        end
+
+        it 'returns false at 120% boundary' do
+          expect(analyzer.send(:deep_otm_strike?, 120, :ce)).to be(false)
+        end
+      end
+
+      context 'for puts' do
+        it 'returns true when below 80% of ATM' do
+          expect(analyzer.send(:deep_otm_strike?, 79, :pe)).to be(true)
+        end
+
+        it 'returns false at 80% boundary' do
+          expect(analyzer.send(:deep_otm_strike?, 80, :pe)).to be(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- invert deep ITM/OTM comparisons for call and put strikes
- add unit tests to cover CE/PE deep strike boundaries

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec; missing gem)*
- `bundle install` *(fails: dhanhq-0.2.3 requires ruby version >= 3.3.0, which is incompatible with the current version, 3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc3ecefb0832aaba93d169f95a33e