### PR TITLE
Handle missing option-chain fields

### DIFF
--- a/app/services/market/analysis_service.rb
+++ b/app/services/market/analysis_service.rb
@@ -227,8 +227,8 @@ module Market
 
         blocks << <<~STR.strip
           ► #{label} (#{strike})
-            CALL: LTP ₹#{ce_ltp.round(2) || '–'}  IV #{ce_iv.round(2) || '–'}%  OI #{ce_oi.round(2) || '–'}  Δ #{ce_delta.round(2) || '–'}  Γ #{ce_gamma.round(2) || '–'}  ν #{ce_vega.round(2) || '–'}  θ #{ce_theta.round(2) || '–'}
-            PUT : LTP ₹#{pe_ltp.round(2) || '–'}  IV #{pe_iv.round(2) || '–'}%  OI #{pe_oi.round(2) || '–'}  Δ #{pe_delta.round(2) || '–'}  Γ #{pe_gamma.round(2) || '–'}  ν #{pe_vega.round(2) || '–'}  θ #{pe_theta.round(2) || '–'}
+            CALL: LTP ₹#{fmt2(ce_ltp)}  IV #{fmt2(ce_iv)}%  OI #{fmt2(ce_oi)}  Δ #{fmt2(ce_delta)}  Γ #{fmt2(ce_gamma)}  ν #{fmt2(ce_vega)}  θ #{fmt2(ce_theta)}
+            PUT : LTP ₹#{fmt2(pe_ltp)}  IV #{fmt2(pe_iv)}%  OI #{fmt2(pe_oi)}  Δ #{fmt2(pe_delta)}  Γ #{fmt2(pe_gamma)}  ν #{fmt2(pe_vega)}  θ #{fmt2(pe_theta)}
         STR
       end
 
@@ -250,6 +250,10 @@ module Market
     def log_missing
       Rails.logger.error "[AnalysisService] ⚠️ Instrument not found: #{@symbol}"
       nil
+    end
+
+    def fmt2(x)
+      x.nil? ? '–' : x.to_f.round(2)
     end
 
     def dig_any(h, *path)

--- a/app/services/market/prompt_builder.rb
+++ b/app/services/market/prompt_builder.rb
@@ -139,6 +139,10 @@ module Market
         x.is_a?(Numeric) ? x.round(1) : '–'
       end
 
+      def fmt2(x)
+        x.nil? ? '–' : x.to_f.round(2)
+      end
+
       # Make the session wording explicit
       def analysis_context_for(session)
         case session
@@ -188,8 +192,8 @@ module Market
 
           blocks << <<~STR.strip
             ► #{label} (#{strike})
-              CALL: LTP ₹#{ce_ltp.round(2) || '–'}  IV #{ce_iv.round(2) || '–'}%  OI #{ce_oi.round(2) || '–'}  Δ #{ce_delta.round(2) || '–'}  Γ #{ce_gamma.round(2) || '–'}  ν #{ce_vega.round(2) || '–'}  θ #{ce_theta.round(2) || '–'}
-              PUT : LTP ₹#{pe_ltp.round(2) || '–'}  IV #{pe_iv.round(2) || '–'}%  OI #{pe_oi.round(2) || '–'}  Δ #{pe_delta.round(2) || '–'}  Γ #{pe_gamma.round(2) || '–'}  ν #{pe_vega.round(2) || '–'}  θ #{pe_theta.round(2) || '–'}
+              CALL: LTP ₹#{fmt2(ce_ltp)}  IV #{fmt2(ce_iv)}%  OI #{fmt2(ce_oi)}  Δ #{fmt2(ce_delta)}  Γ #{fmt2(ce_gamma)}  ν #{fmt2(ce_vega)}  θ #{fmt2(ce_theta)}
+              PUT : LTP ₹#{fmt2(pe_ltp)}  IV #{fmt2(pe_iv)}%  OI #{fmt2(pe_oi)}  Δ #{fmt2(pe_delta)}  Γ #{fmt2(pe_gamma)}  ν #{fmt2(pe_vega)}  θ #{fmt2(pe_theta)}
           STR
         end
 

--- a/spec/services/market/format_options_chain_spec.rb
+++ b/spec/services/market/format_options_chain_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Option chain formatting' do
+  let(:options) do
+    {
+      atm: {
+        strike: 12_345,
+        call: { 'last_price' => 12.345 }
+        # put missing to simulate incomplete row
+      }
+    }
+  end
+
+  describe Market::PromptBuilder do
+    it 'handles incomplete rows with placeholders' do
+      formatted = described_class.send(:format_options_chain, options)
+
+      expect(formatted).to include('CALL: LTP ₹12.35')
+      expect(formatted).to include('IV –%')
+      expect(formatted).to include('PUT : LTP ₹–')
+    end
+  end
+
+  describe Market::AnalysisService do
+    subject(:service) { described_class.new('NIFTY') }
+
+    it 'handles incomplete rows with placeholders' do
+      formatted = service.send(:format_options_chain, options)
+
+      expect(formatted).to include('CALL: LTP ₹12.35')
+      expect(formatted).to include('IV –%')
+      expect(formatted).to include('PUT : LTP ₹–')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- avoid calling `round` on nil option-chain data
- show placeholder `–` for missing values
- cover incomplete option-chain rows with specs

## Testing
- `bundle exec rspec spec/services/market/format_options_chain_spec.rb` *(fails: command not found)*
- `bundle exec rake spec spec/services/market/format_options_chain_spec.rb` *(fails: Could not find rails-8.0.1 ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc3fc246c832aab03770a2cd34e5a