### PR TITLE
Replace debug prints with structured logging

### DIFF
--- a/app/services/alert_processors/index.rb
+++ b/app/services/alert_processors/index.rb
@@ -310,7 +310,7 @@ module AlertProcessors
       end
 
       rr = rrules_for(live) || rrules_for(strike[:last_price])
-      pp rr, live
+      log :debug, { rrules: rr, live_price: live }.to_json
       {
         transactionType: SIGNAL_TO_SIDE.fetch(alert[:signal_type]), # BUY
         exchangeSegment: derivative.exchange_segment,

--- a/app/services/dhan/ws/depth_listener.rb
+++ b/app/services/dhan/ws/depth_listener.rb
@@ -30,7 +30,7 @@ module Dhan
             EM.stop
             run
           end
-          ws.on(:error) { |e| puts "[Depth] ⚠ Error: #{e.message}" }
+          ws.on(:error) { |e| Rails.logger.error { "[Depth] ⚠ Error: #{e.message}" } }
         end
       end
 

--- a/app/services/dhan/ws/feed_listener.rb
+++ b/app/services/dhan/ws/feed_listener.rb
@@ -28,11 +28,11 @@ module Dhan
       def self.run
         Positions::ActiveCache.refresh!
         EM.run do
-          pp "[WS] Connecting to #{FEED_URL}"
+          Rails.logger.debug { "[WS] Connecting to #{FEED_URL}" }
           ws = Faye::WebSocket::Client.new(FEED_URL)
 
           ws.on(:open) do
-            pp '[WS] ▶ Connected'
+            Rails.logger.debug '[WS] ▶ Connected'
             subscribe(ws)
 
             EM.add_periodic_timer(Positions::ActiveCache::REFRESH_SEC) do
@@ -46,13 +46,13 @@ module Dhan
           end
 
           ws.on(:close) do |event|
-            pp "[WS] ✖ Disconnected (#{event.code}): #{event.reason}"
+            Rails.logger.warn { "[WS] ✖ Disconnected (#{event.code}): #{event.reason}" }
             EM.stop
             sleep 1
             run
           end
           ws.on(:error) do |event|
-            pp "[WS] ⚠ Error: #{event.message}"
+            Rails.logger.error { "[WS] ⚠ Error: #{event.message}" }
           end
         end
       end
@@ -102,7 +102,7 @@ module Dhan
           }
 
           ws.send(payload.to_json)
-          pp "[WS] 📡 Subscribed #{batch.size} instruments via code #{request_code}: #{batch.pluck(:SecurityId).join(', ')}"
+          Rails.logger.debug { "[WS] 📡 Subscribed #{batch.size} instruments via code #{request_code}: #{batch.pluck(:SecurityId).join(', ')}" }
         end
       end
 
@@ -119,9 +119,9 @@ module Dhan
         when 4
           QuoteHandler.call(packet)
         when 50
-          pp "[WS] ✖ Disconnection for SID=#{packet[:security_id]} Code=#{packet[:disconnection_code]}"
+          Rails.logger.warn { "[WS] ✖ Disconnection for SID=#{packet[:security_id]} Code=#{packet[:disconnection_code]}" }
         else
-          pp "[WS] Ignored packet type: #{packet[:feed_response_code]}"
+          Rails.logger.debug { "[WS] Ignored packet type: #{packet[:feed_response_code]}" }
         end
       rescue StandardError => e
         Rails.logger.error "[WS] ❌ Parse/Dispatch Error: #{e.class} - #{e.message}"
@@ -177,7 +177,7 @@ module Dhan
 
         name = instrument&.symbol_name || key
 
-        pp "[WS] 🔄 #{name} LTP changed: #{prev_ltp} → #{new_ltp}"
+        Rails.logger.debug { "[WS] 🔄 #{name} LTP changed: #{prev_ltp} → #{new_ltp}" }
       end
     end
   end

--- a/lib/openai/chat_router.rb
+++ b/lib/openai/chat_router.rb
@@ -14,8 +14,7 @@ module Openai
                   max_tokens: nil,
                   force: false)
       mdl = resolve_model(model, force, "#{system} #{user_prompt}")
-
-      pp mdl
+      Rails.logger.debug { { model: mdl }.to_json }
       params = {
         model: mdl,
         messages: [

--- a/lib/tasks/exit_debug.rake
+++ b/lib/tasks/exit_debug.rake
@@ -34,12 +34,12 @@ namespace :exit_debug do
     decision = Orders::RiskManager.call(pos, analysis)
 
     puts '✅ Position:'
-    pp pos
+    Rails.logger.debug { pos.inspect }
 
     puts '📈 Analysis:'
-    pp analysis
+    Rails.logger.debug { analysis.inspect }
 
     puts '📌 Decision:'
-    pp decision
+    Rails.logger.debug { decision.inspect }
   end
 end


### PR DESCRIPTION
## Summary
- remove stray `pp` debug output from order payload builder
- convert websocket feed listener prints to structured Rails logger calls
- switch remaining debug statements to structured logging

## Testing
- `bundle exec rspec` *(fails: command not found)*
- `bundle install` *(fails: dhanhq-0.2.3 requires ruby >= 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc3ffffd4832a8aed4f4f8f94c1ba