### PR TITLE
Use adaptive Supertrend via adapter and env flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,22 @@ RISK_PER_TRADE_PCT=0.03
 DAILY_MAX_LOSS_PCT=0.05
 ```
 
+### Adaptive Supertrend
+
+Toggle between the classic `Indicators::Supertrend` and the machine-learning
+powered `Indicators::AdaptiveSupertrend` using environment flags:
+
+```bash
+USE_ADAPTIVE_ST=true       # set to false to fallback to classic Supertrend
+ADAPTIVE_ST_TRAINING=50    # warm-up window before signals are valid
+ADAPTIVE_ST_CLUSTERS=3     # number of volatility clusters
+ADAPTIVE_ST_ALPHA=0.1      # performance tracking learning rate
+```
+
+For short series (`< training_period + period`) the adaptive indicator returns
+`nil` values until enough data has accumulated, so callers should handle `nil`
+gracefully.
+
 ### Capital Bands Customization
 Edit the `CAPITAL_BANDS` constant in alert processors to customize:
 ```ruby

--- a/app/models/candle_series.rb
+++ b/app/models/candle_series.rb
@@ -174,11 +174,13 @@ class CandleSeries
   # Trend utilities (Supertrend, Bollinger, Donchian…)
   # ---------------------------------------------------------------------------
   def supertrend_signal
-    trend_line = Indicators::Supertrend.new(series: self).call
+    trend_line = (@supertrend_line ||= Indicators.build_supertrend(series: self, period: 10, multiplier: 2))
     return nil if trend_line.empty?
 
-    latest_close = closes.last
     latest_trend = trend_line.last
+    return nil if latest_trend.nil?
+
+    latest_close = closes.last
 
     return :bullish if latest_close > latest_trend
 

--- a/app/services/indicators/supertrend_builder.rb
+++ b/app/services/indicators/supertrend_builder.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Indicators
+  class << self
+    def build_supertrend(series:, period:, multiplier:)
+      use_adaptive = ENV.fetch('USE_ADAPTIVE_ST', Rails.env.production? ? 'true' : 'false') == 'true'
+      training_period   = ENV.fetch('ADAPTIVE_ST_TRAINING', '50').to_i
+      num_clusters      = ENV.fetch('ADAPTIVE_ST_CLUSTERS', '3').to_i
+      performance_alpha = ENV.fetch('ADAPTIVE_ST_ALPHA', '0.1').to_f
+
+      klass = use_adaptive ? Indicators::AdaptiveSupertrend : Indicators::Supertrend
+
+      log_choice(klass, training_period, num_clusters, performance_alpha)
+
+      if use_adaptive
+        klass.new(
+          series: series,
+          period: period,
+          base_multiplier: multiplier,
+          training_period: training_period,
+          num_clusters: num_clusters,
+          performance_alpha: performance_alpha
+        ).call
+      else
+        klass.new(series: series, period: period, multiplier: multiplier).call
+      end
+    end
+
+    private
+
+    def log_choice(klass, training_period, num_clusters, performance_alpha)
+      return if @logged
+
+      if klass == Indicators::AdaptiveSupertrend
+        Rails.logger.info(
+          "[Indicators] AdaptiveSupertrend active (training=#{training_period}, clusters=#{num_clusters}, alpha=#{performance_alpha})"
+        )
+      else
+        Rails.logger.info('[Indicators] Using classic Supertrend')
+      end
+      @logged = true
+    end
+  end
+end

--- a/config/initializers/adaptive_supertrend.rb
+++ b/config/initializers/adaptive_supertrend.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+ENV['USE_ADAPTIVE_ST'] ||= Rails.env.production? ? 'true' : 'false'
+ENV['ADAPTIVE_ST_TRAINING'] ||= '50'
+ENV['ADAPTIVE_ST_CLUSTERS'] ||= '3'
+ENV['ADAPTIVE_ST_ALPHA'] ||= '0.1'
+
+require Rails.root.join('app/services/indicators/supertrend_builder.rb')

--- a/spec/models/candle_series_supertrend_spec.rb
+++ b/spec/models/candle_series_supertrend_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CandleSeries, '#supertrend_signal' do
+  around do |example|
+    orig = ENV['USE_ADAPTIVE_ST']
+    ENV['USE_ADAPTIVE_ST'] = 'true'
+    example.run
+    ENV['USE_ADAPTIVE_ST'] = orig
+  end
+
+  it 'returns nil when series is shorter than training window' do
+    series = described_class.new(symbol: 'TEST')
+    10.times do |i|
+      price = 100 + i
+      series.add_candle(
+        Candle.new(ts: Time.at(i), open: price, high: price + 1, low: price - 1, close: price, volume: 100)
+      )
+    end
+    expect(series.supertrend_signal).to be_nil
+  end
+
+  it 'returns a trend symbol once warmed up' do
+    series = described_class.new(symbol: 'TEST')
+    100.times do |i|
+      price = 100 + i
+      series.add_candle(
+        Candle.new(ts: Time.at(i), open: price, high: price + 1, low: price - 1, close: price, volume: 100)
+      )
+    end
+    expect(series.supertrend_signal).to be_in(%i[bullish bearish])
+  end
+end

--- a/spec/services/indicators/build_supertrend_spec.rb
+++ b/spec/services/indicators/build_supertrend_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Supertrend builder' do
+  let(:series) do
+    cs = CandleSeries.new(symbol: 'TEST')
+    100.times do |i|
+      price = 100 + i
+      cs.add_candle(
+        Candle.new(ts: Time.at(i), open: price, high: price + 1, low: price - 1, close: price, volume: 100)
+      )
+    end
+    cs
+  end
+
+  context 'with adaptive enabled' do
+    around do |example|
+      orig = ENV['USE_ADAPTIVE_ST']
+      ENV['USE_ADAPTIVE_ST'] = 'true'
+      example.run
+      ENV['USE_ADAPTIVE_ST'] = orig
+    end
+
+    it 'returns array aligned with series and leading nils during warm up' do
+      result = Indicators.build_supertrend(series: series, period: 10, multiplier: 2)
+      expect(result.length).to eq(series.candles.length)
+      training = ENV.fetch('ADAPTIVE_ST_TRAINING', '50').to_i
+      expect(result.first(training)).to all(be_nil)
+      expect(result.drop(training).compact).to all(be_a(Float))
+    end
+  end
+
+  context 'with adaptive disabled' do
+    around do |example|
+      orig = ENV['USE_ADAPTIVE_ST']
+      ENV['USE_ADAPTIVE_ST'] = 'false'
+      example.run
+      ENV['USE_ADAPTIVE_ST'] = orig
+    end
+
+    it 'falls back to classic supertrend' do
+      classic = Indicators::Supertrend.new(series: series).call
+      result = Indicators.build_supertrend(series: series, period: 10, multiplier: 2)
+      expect(result).to eq(classic)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `Indicators.build_supertrend` to switch between classic and adaptive Supertrend, logging choice and honouring env configuration
- default adaptive Supertrend settings via initializer and swap `CandleSeries#supertrend_signal` to use adapter with nil-safe warmup handling
- document env flags and add specs for builder and candle-series integration

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*


------
https://chatgpt.com/codex/tasks/task_e_68bebefcc5cc832aa0bb2a8347afd50c