### PR TITLE
Use adaptive Supertrend via adapter and app settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,24 @@ RISK_PER_TRADE_PCT=0.03
 DAILY_MAX_LOSS_PCT=0.05
 ```
 
+### Adaptive Supertrend
+
+Toggle between the classic `Indicators::Supertrend` and the machine-learning
+powered `Indicators::AdaptiveSupertrend` using `AppSetting` keys:
+
+```
+AppSetting['use_adaptive_st']      = true   # set to false to fallback to classic Supertrend
+AppSetting['adaptive_st_training'] = 50     # warm-up window before signals are valid
+AppSetting['adaptive_st_clusters'] = 3      # number of volatility clusters
+AppSetting['adaptive_st_alpha']    = 0.1    # performance tracking learning rate
+AppSetting['supertrend_period']    = 10     # ATR look-back period
+AppSetting['supertrend_multiplier']= 2.0    # ATR multiplier
+```
+
+For short series (`< training_period + period`) the adaptive indicator returns
+`nil` values until enough data has accumulated, so callers should handle `nil`
+gracefully.
+
 ### Capital Bands Customization
 Edit the `CAPITAL_BANDS` constant in alert processors to customize:
 ```ruby

--- a/app/models/candle_series.rb
+++ b/app/models/candle_series.rb
@@ -174,11 +174,17 @@ class CandleSeries
   # Trend utilities (Supertrend, Bollinger, Donchian…)
   # ---------------------------------------------------------------------------
   def supertrend_signal
-    trend_line = Indicators::Supertrend.new(series: self).call
+    period = AppSetting.fetch_int('supertrend_period', default: 10)
+    multiplier = AppSetting.fetch_float('supertrend_multiplier', default: 2.0)
+    trend_line = (
+      @supertrend_line ||= Indicators.build_supertrend(series: self, period: period, multiplier: multiplier)
+    )
     return nil if trend_line.empty?
 
-    latest_close = closes.last
     latest_trend = trend_line.last
+    return nil if latest_trend.nil?
+
+    latest_close = closes.last
 
     return :bullish if latest_close > latest_trend
 

--- a/app/services/indicators/supertrend_builder.rb
+++ b/app/services/indicators/supertrend_builder.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Indicators
+  class << self
+    def build_supertrend(series:, period:, multiplier:)
+      use_adaptive = AppSetting.fetch_bool('use_adaptive_st', default: Rails.env.production?)
+      training_period   = AppSetting.fetch_int('adaptive_st_training',   default: 50)
+      num_clusters      = AppSetting.fetch_int('adaptive_st_clusters',   default: 3)
+      performance_alpha = AppSetting.fetch_float('adaptive_st_alpha',    default: 0.1)
+
+      klass = use_adaptive ? Indicators::AdaptiveSupertrend : Indicators::Supertrend
+
+      log_choice(klass, training_period, num_clusters, performance_alpha)
+
+      if use_adaptive
+        klass.new(
+          series: series,
+          period: period,
+          base_multiplier: multiplier,
+          training_period: training_period,
+          num_clusters: num_clusters,
+          performance_alpha: performance_alpha
+        ).call
+      else
+        klass.new(series: series, period: period, multiplier: multiplier).call
+      end
+    end
+
+    private
+
+    def log_choice(klass, training_period, num_clusters, performance_alpha)
+      return if @logged
+
+      if klass == Indicators::AdaptiveSupertrend
+        Rails.logger.info(
+          "[Indicators] AdaptiveSupertrend active (training=#{training_period}, clusters=#{num_clusters}, alpha=#{performance_alpha})"
+        )
+      else
+        Rails.logger.info('[Indicators] Using classic Supertrend')
+      end
+      @logged = true
+    end
+  end
+end

--- a/config/initializers/adaptive_supertrend.rb
+++ b/config/initializers/adaptive_supertrend.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require Rails.root.join('app/services/indicators/supertrend_builder.rb')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Seed application configuration values
+load Rails.root.join('db/seeds/app_settings.rb')
+
 # Strategies Data
 STRATEGIES_DATA = [
   {

--- a/db/seeds/app_settings.rb
+++ b/db/seeds/app_settings.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Seed key-value configuration settings used by the application
+AppSetting.find_or_create_by!(key: 'use_adaptive_st') do |s|
+  s.value = Rails.env.production?.to_s
+end
+
+AppSetting.find_or_create_by!(key: 'adaptive_st_training') do |s|
+  s.value = '50'
+end
+
+AppSetting.find_or_create_by!(key: 'adaptive_st_clusters') do |s|
+  s.value = '3'
+end
+
+AppSetting.find_or_create_by!(key: 'adaptive_st_alpha') do |s|
+  s.value = '0.1'
+end
+
+AppSetting.find_or_create_by!(key: 'supertrend_period') do |s|
+  s.value = '10'
+end
+
+AppSetting.find_or_create_by!(key: 'supertrend_multiplier') do |s|
+  s.value = '2.0'
+end

--- a/spec/models/candle_series_supertrend_spec.rb
+++ b/spec/models/candle_series_supertrend_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CandleSeries, '#supertrend_signal' do
+  before do
+    allow(AppSetting).to receive(:fetch_bool).with('use_adaptive_st', default: false).and_return(true)
+    allow(AppSetting).to receive(:fetch_int).with('adaptive_st_training',   default: 50).and_return(50)
+    allow(AppSetting).to receive(:fetch_int).with('adaptive_st_clusters',   default: 3).and_return(3)
+    allow(AppSetting).to receive(:fetch_float).with('adaptive_st_alpha',    default: 0.1).and_return(0.1)
+    allow(AppSetting).to receive(:fetch_int).with('supertrend_period', default: 10).and_return(10)
+    allow(AppSetting).to receive(:fetch_float).with('supertrend_multiplier', default: 2.0).and_return(2.0)
+  end
+
+  it 'returns nil when series is shorter than training window' do
+    series = described_class.new(symbol: 'TEST')
+    10.times do |i|
+      price = 100 + i
+      series.add_candle(
+        Candle.new(ts: Time.at(i), open: price, high: price + 1, low: price - 1, close: price, volume: 100)
+      )
+    end
+    expect(series.supertrend_signal).to be_nil
+  end
+
+  it 'returns a trend symbol once warmed up' do
+    series = described_class.new(symbol: 'TEST')
+    100.times do |i|
+      price = 100 + i
+      series.add_candle(
+        Candle.new(ts: Time.at(i), open: price, high: price + 1, low: price - 1, close: price, volume: 100)
+      )
+    end
+    expect(series.supertrend_signal).to be_in(%i[bullish bearish])
+  end
+end

--- a/spec/services/indicators/build_supertrend_spec.rb
+++ b/spec/services/indicators/build_supertrend_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Supertrend builder' do
+  let(:series) do
+    cs = CandleSeries.new(symbol: 'TEST')
+    100.times do |i|
+      price = 100 + i
+      cs.add_candle(
+        Candle.new(ts: Time.at(i), open: price, high: price + 1, low: price - 1, close: price, volume: 100)
+      )
+    end
+    cs
+  end
+
+  context 'with adaptive enabled' do
+    before do
+      allow(AppSetting).to receive(:fetch_bool).with('use_adaptive_st', default: false).and_return(true)
+      allow(AppSetting).to receive(:fetch_int).with('adaptive_st_training',   default: 50).and_return(50)
+      allow(AppSetting).to receive(:fetch_int).with('adaptive_st_clusters',   default: 3).and_return(3)
+      allow(AppSetting).to receive(:fetch_float).with('adaptive_st_alpha',    default: 0.1).and_return(0.1)
+    end
+
+    it 'returns array aligned with series and leading nils during warm up' do
+      result = Indicators.build_supertrend(series: series, period: 10, multiplier: 2)
+      expect(result.length).to eq(series.candles.length)
+      training = AppSetting.fetch_int('adaptive_st_training', default: 50)
+      expect(result.first(training)).to all(be_nil)
+      expect(result.drop(training).compact).to all(be_a(Float))
+    end
+  end
+
+  context 'with adaptive disabled' do
+    before do
+      allow(AppSetting).to receive(:fetch_bool).with('use_adaptive_st', default: false).and_return(false)
+    end
+
+    it 'falls back to classic supertrend' do
+      classic = Indicators::Supertrend.new(series: series).call
+      result = Indicators.build_supertrend(series: series, period: 10, multiplier: 2)
+      expect(result).to eq(classic)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `Indicators.build_supertrend` to switch between classic and adaptive Supertrend, logging choice and honoring app settings
- default adaptive Supertrend settings via initializer and swap `CandleSeries#supertrend_signal` to use adapter with nil-safe warmup handling
- document app-setting flags, add specs for builder and candle-series integration, and seed supertrend configuration values

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68bebefcc5cc832aa0bb2a8347afd50c