### PR TITLE
Seed hard-coded configuration values

### DIFF
--- a/app/models/app_setting.rb
+++ b/app/models/app_setting.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 class AppSetting < ApplicationRecord
   self.primary_key = :key
   validates :key, :value, presence: true
@@ -32,5 +34,16 @@ class AppSetting < ApplicationRecord
   def self.fetch_int(key, default:)
     k = key.to_s
     INTEGER.cast(self[k] || ENV[k.upcase] || default)
+  end
+
+  #  Array/JSON helper – parses JSON stored value or falls back to default
+  def self.fetch_array(key, default:)
+    k = key.to_s
+    raw = self[k] || ENV[k.upcase]
+    return default if raw.blank?
+
+    JSON.parse(raw)
+  rescue JSON::ParserError
+    default
   end
 end

--- a/app/services/alert_processors/index.rb
+++ b/app/services/alert_processors/index.rb
@@ -36,12 +36,16 @@ module AlertProcessors
     # Capital-aware deployment policy
     # ──────────────────────────────────────────────────────────────────
     # Bands are inclusive upper-bounds. Tweak as you like.
-    CAPITAL_BANDS = [
-      { upto: 75_000, alloc_pct: 0.30, risk_per_trade_pct: 0.050, daily_max_loss_pct: 0.050 }, # small a/c (≈ ₹50k)
-      { upto: 150_000,  alloc_pct: 0.25, risk_per_trade_pct: 0.035, daily_max_loss_pct: 0.060 }, # ≈ ₹1L
-      { upto: 300_000,  alloc_pct: 0.20, risk_per_trade_pct: 0.030, daily_max_loss_pct: 0.060 }, # ≈ ₹2–3L
-      { upto: Float::INFINITY, alloc_pct: 0.20, risk_per_trade_pct: 0.025, daily_max_loss_pct: 0.050 }
-    ].freeze
+    CAPITAL_BANDS = AppSetting
+                      .fetch_array('capital_bands_index',
+                                   default: [
+                                     { 'upto' => 75_000,  'alloc_pct' => 0.30, 'risk_per_trade_pct' => 0.050, 'daily_max_loss_pct' => 0.050 },
+                                     { 'upto' => 150_000, 'alloc_pct' => 0.25, 'risk_per_trade_pct' => 0.035, 'daily_max_loss_pct' => 0.060 },
+                                     { 'upto' => 300_000, 'alloc_pct' => 0.20, 'risk_per_trade_pct' => 0.030, 'daily_max_loss_pct' => 0.060 },
+                                     { 'upto' => nil,     'alloc_pct' => 0.20, 'risk_per_trade_pct' => 0.025, 'daily_max_loss_pct' => 0.050 }
+                                   ])
+                      .map { |b| b['upto'] = Float::INFINITY if b['upto'].nil?; b.symbolize_keys }
+                      .freeze
 
     # Entry-point that the Sidekiq job / controller calls
     # ----------------------------------------------------------------

--- a/app/services/alert_processors/stock.rb
+++ b/app/services/alert_processors/stock.rb
@@ -33,12 +33,16 @@ module AlertProcessors
     # ──────────────────────────────────────────────────────────────────
     # Capital-aware deployment policy
     # ──────────────────────────────────────────────────────────────────
-    CAPITAL_BANDS = [
-      { upto: 75_000, alloc_pct: 0.30, risk_per_trade_pct: 0.050, daily_max_loss_pct: 0.050 }, # small a/c (≈ ₹50k)
-      { upto: 150_000,  alloc_pct: 0.25, risk_per_trade_pct: 0.035, daily_max_loss_pct: 0.060 }, # ≈ ₹1L
-      { upto: 300_000,  alloc_pct: 0.20, risk_per_trade_pct: 0.030, daily_max_loss_pct: 0.060 }, # ≈ ₹2–3L
-      { upto: Float::INFINITY, alloc_pct: 0.20, risk_per_trade_pct: 0.025, daily_max_loss_pct: 0.050 }
-    ].freeze
+    CAPITAL_BANDS = AppSetting
+                      .fetch_array('capital_bands_stock',
+                                   default: [
+                                     { 'upto' => 75_000,  'alloc_pct' => 0.30, 'risk_per_trade_pct' => 0.050, 'daily_max_loss_pct' => 0.050 },
+                                     { 'upto' => 150_000, 'alloc_pct' => 0.25, 'risk_per_trade_pct' => 0.035, 'daily_max_loss_pct' => 0.060 },
+                                     { 'upto' => 300_000, 'alloc_pct' => 0.20, 'risk_per_trade_pct' => 0.030, 'daily_max_loss_pct' => 0.060 },
+                                     { 'upto' => nil,     'alloc_pct' => 0.20, 'risk_per_trade_pct' => 0.025, 'daily_max_loss_pct' => 0.050 }
+                                   ])
+                      .map { |b| b['upto'] = Float::INFINITY if b['upto'].nil?; b.symbolize_keys }
+                      .freeze
 
     # ------------------------------------------------------------------------
     #  Entry‑point (called from controller / worker)

--- a/app/services/dhan/ws/feed_listener.rb
+++ b/app/services/dhan/ws/feed_listener.rb
@@ -20,11 +20,15 @@ module Dhan
       @segment_cache ||= {}
       @ltp_cache ||= {}
 
-      # Always subscribe to NIFTY + BANKNIFTY
-      INDEXES = [
-        { security_id: '13', exchange_segment: 'IDX_I' },
-        { security_id: '25', exchange_segment: 'IDX_I' }
-      ].freeze
+      # Always subscribe to key index instruments
+      INDEXES = AppSetting
+                  .fetch_array('feed_indexes',
+                               default: [
+                                 { 'security_id' => '13', 'exchange_segment' => 'IDX_I' },
+                                 { 'security_id' => '25', 'exchange_segment' => 'IDX_I' }
+                               ])
+                  .map { |h| h.symbolize_keys }
+                  .freeze
 
       def self.run
         Positions::ActiveCache.refresh!

--- a/app/services/instruments_importer.rb
+++ b/app/services/instruments_importer.rb
@@ -6,8 +6,8 @@ require 'open-uri'
 class InstrumentsImporter
   CSV_URL = 'https://images.dhan.co/api-data/api-scrip-master-detailed.csv'
 
-  VALID_EXCHANGES = %w[NSE BSE MCX].freeze
-  VALID_INSTRUMENTS = %w[OPTIDX FUTIDX OPTSTK FUTSTK FUTCUR OPTCUR FUTCOM OPTFUT EQUITY INDEX].freeze
+  VALID_EXCHANGES   = AppSetting.fetch_array('valid_exchanges',   default: %w[NSE BSE MCX]).freeze
+  VALID_INSTRUMENTS = AppSetting.fetch_array('valid_instruments', default: %w[OPTIDX FUTIDX OPTSTK FUTSTK FUTCUR OPTCUR FUTCOM OPTFUT EQUITY INDEX]).freeze
   BATCH_SIZE = 500
 
   def self.import(file_path = nil)

--- a/app/services/market/analysis_updater.rb
+++ b/app/services/market/analysis_updater.rb
@@ -2,7 +2,8 @@ module Market
   class AnalysisUpdater < ApplicationService
     INTERVAL  = '5'.freeze # 5-minute candles
     PERIODS   = 50 # pull ~4 hours (enough for ATR14)
-    SYMBOLS   = %w[NIFTY BANKNIFTY SENSEX].freeze
+    SYMBOLS   = AppSetting.fetch_array('analysis_symbols',
+                                       default: %w[NIFTY BANKNIFTY SENSEX]).freeze
 
     # ------------------------------------------------------------------
     # 🗓  Trading-day helpers

--- a/app/services/market_calendar.rb
+++ b/app/services/market_calendar.rb
@@ -1,14 +1,12 @@
 module MarketCalendar
-  MARKET_HOLIDAYS = [
-    # Add static or API-fetched holiday dates here
-    Date.new(2025, 8, 15),
-    Date.new(2025, 8, 27)
-    # ...
-  ].freeze
+  def self.market_holidays
+    @market_holidays ||= AppSetting.fetch_array('market_holidays', default: [])
+                                     .map { |d| Date.parse(d) }
+  end
 
   def self.trading_day?(date)
     weekday = date.on_weekday?
-    !MARKET_HOLIDAYS.include?(date) && weekday
+    !market_holidays.include?(date) && weekday
   end
 
   def self.last_trading_day(from: Time.zone.today)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -147,3 +147,5 @@ STRATEGIES_DATA.each do |strategy_data|
 end
 
 Rails.logger.debug { "Seeded #{STRATEGIES_DATA.size} strategies successfully." }
+
+require_relative 'seeds/hard_coded_values'

--- a/db/seeds/hard_coded_values.rb
+++ b/db/seeds/hard_coded_values.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Seed values previously hard-coded in the application
+
+AppSetting.find_or_create_by!(key: 'market_holidays') do |s|
+  s.value = ['2025-08-15', '2025-08-27'].to_json
+end
+
+AppSetting.find_or_create_by!(key: 'valid_exchanges') do |s|
+  s.value = %w[NSE BSE MCX].to_json
+end
+
+AppSetting.find_or_create_by!(key: 'valid_instruments') do |s|
+  s.value = %w[OPTIDX FUTIDX OPTSTK FUTSTK FUTCUR OPTCUR FUTCOM OPTFUT EQUITY INDEX].to_json
+end
+
+AppSetting.find_or_create_by!(key: 'analysis_symbols') do |s|
+  s.value = %w[NIFTY BANKNIFTY SENSEX].to_json
+end
+
+AppSetting.find_or_create_by!(key: 'feed_indexes') do |s|
+  s.value = [
+    { security_id: '13', exchange_segment: 'IDX_I' },
+    { security_id: '25', exchange_segment: 'IDX_I' }
+  ].to_json
+end
+
+AppSetting.find_or_create_by!(key: 'capital_bands_index') do |s|
+  s.value = [
+    { upto: 75_000, alloc_pct: 0.30, risk_per_trade_pct: 0.050, daily_max_loss_pct: 0.050 },
+    { upto: 150_000, alloc_pct: 0.25, risk_per_trade_pct: 0.035, daily_max_loss_pct: 0.060 },
+    { upto: 300_000, alloc_pct: 0.20, risk_per_trade_pct: 0.030, daily_max_loss_pct: 0.060 },
+    { upto: nil,     alloc_pct: 0.20, risk_per_trade_pct: 0.025, daily_max_loss_pct: 0.050 }
+  ].to_json
+end
+
+AppSetting.find_or_create_by!(key: 'capital_bands_stock') do |s|
+  s.value = [
+    { upto: 75_000, alloc_pct: 0.30, risk_per_trade_pct: 0.050, daily_max_loss_pct: 0.050 },
+    { upto: 150_000, alloc_pct: 0.25, risk_per_trade_pct: 0.035, daily_max_loss_pct: 0.060 },
+    { upto: 300_000, alloc_pct: 0.20, risk_per_trade_pct: 0.030, daily_max_loss_pct: 0.060 },
+    { upto: nil,     alloc_pct: 0.20, risk_per_trade_pct: 0.025, daily_max_loss_pct: 0.050 }
+  ].to_json
+end
+
+Rails.logger.debug { 'Seeded hard-coded configuration values.' }


### PR DESCRIPTION
## Summary
- move various hard-coded arrays and hashes into AppSetting entries
- load these values from AppSetting across services
- seed default configuration for exchanges, instruments, holidays, feed indexes, analysis symbols, and capital bands

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: dhanhq-0.2.3 requires ruby version >= 3.3.0)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_68bedbac11ac832a82b90eb3fc6857a0