### PR TITLE
Use adaptive supertrend for trend signal

### DIFF
--- a/app/models/candle_series.rb
+++ b/app/models/candle_series.rb
@@ -171,14 +171,15 @@ class CandleSeries
   end
 
   # ---------------------------------------------------------------------------
-  # Trend utilities (Supertrend, Bollinger, Donchian…)
+  # Trend utilities (Adaptive Supertrend, Bollinger, Donchian…)
   # ---------------------------------------------------------------------------
   def supertrend_signal
-    trend_line = Indicators::Supertrend.new(series: self).call
-    return nil if trend_line.empty?
+    indicator   = Indicators::AdaptiveSupertrend.new(series: self)
+    trend_line  = indicator.call
+    latest_trend = trend_line.last
+    return nil unless latest_trend
 
     latest_close = closes.last
-    latest_trend = trend_line.last
 
     return :bullish if latest_close > latest_trend
 


### PR DESCRIPTION
## Summary
- Replace simple Supertrend with Adaptive Supertrend for trend signal
- Guard against missing trend data when computing adaptive Supertrend signal

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: dhanhq-0.2.3 requires ruby version >= 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c63e6d8c90832abcaa35cc22f5ffe6