### PR TITLE
Add manual Telegram option trigger commands

### DIFF
--- a/app/services/telegram_bot/manual_signal_trigger.rb
+++ b/app/services/telegram_bot/manual_signal_trigger.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module TelegramBot
+  # ManualSignalTrigger allows triggering the existing index alert pipeline from
+  # Telegram commands (e.g. "nifty ce" / "banknifty pe"). It creates a minimal
+  # Alert record that mimics the TradingView payload and then hands it off to the
+  # regular AlertProcessor.
+  class ManualSignalTrigger < ApplicationService
+    def initialize(chat_id:, symbol:, option:, exchange: :nse)
+      @chat_id = chat_id
+      @symbol = symbol.to_s.upcase
+      @option = option.to_sym
+      @exchange = exchange.to_sym
+    end
+
+    def call
+      TelegramNotifier.send_chat_action(chat_id: @chat_id, action: 'typing')
+
+      instrument = find_instrument!
+      alert = create_alert!(instrument)
+
+      AlertProcessorFactory.build(alert).call
+
+      TelegramNotifier.send_message(success_message(alert), chat_id: @chat_id)
+
+      alert
+    rescue ActiveRecord::RecordNotFound => e
+      log_error("Instrument lookup failed for #{@symbol}: #{e.message}")
+      TelegramNotifier.send_message(
+        "⚠️ Unable to trigger #{@symbol} #{@option.to_s.upcase} – instrument not configured.",
+        chat_id: @chat_id
+      )
+      nil
+    rescue StandardError => e
+      log_error("Manual signal failed – #{e.class}: #{e.message}")
+      TelegramNotifier.send_message(
+        "🚨 Manual signal for #{@symbol} #{@option.to_s.upcase} failed – #{e.message}",
+        chat_id: @chat_id
+      )
+      nil
+    end
+
+    private
+
+    def find_instrument!
+      Instrument
+        .where('LOWER(underlying_symbol) = ?', @symbol.downcase)
+        .where('LOWER(exchange) = ?', exchange_code)
+        .where('LOWER(segment) = ?', 'index')
+        .first!
+    end
+
+    def create_alert!(instrument)
+      instrument.alerts.create!(base_alert_attributes(instrument))
+    end
+
+    def base_alert_attributes(instrument)
+      {
+        ticker: @symbol,
+        instrument_type: 'index',
+        exchange: exchange_code.upcase,
+        order_type: 'market',
+        action: 'buy',
+        signal_type: signal_type,
+        strategy_type: 'intraday',
+        strategy_name: 'Manual Telegram Signal',
+        strategy_id: SecureRandom.uuid,
+        current_position: 'flat',
+        previous_position: 'flat',
+        current_price: fetch_current_price(instrument),
+        chart_interval: 'manual',
+        time: Time.zone.now.iso8601,
+        metadata: {
+          'triggered_by' => 'telegram_manual',
+          'option_type' => @option.to_s.upcase
+        }
+      }
+    end
+
+    def fetch_current_price(instrument)
+      price = instrument.quote_ltp || instrument.ltp
+      price.present? ? price.to_f : 0.0
+    rescue StandardError
+      0.0
+    end
+
+    def signal_type
+      @option == :ce ? 'long_entry' : 'short_entry'
+    end
+
+    def exchange_code
+      @exchange.to_s.downcase
+    end
+
+    def success_message(alert)
+      "✅ Manual #{@symbol} #{@option.to_s.upcase} signal queued.\nAlert ##{alert.id} is being processed."
+    end
+  end
+end

--- a/spec/services/telegram_bot/command_handler_spec.rb
+++ b/spec/services/telegram_bot/command_handler_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TelegramBot::CommandHandler do
+  let(:chat_id) { 'chat-1' }
+
+  before do
+    allow(TelegramNotifier).to receive(:send_message)
+  end
+
+  describe '#call' do
+    it 'delegates nifty ce command to the manual trigger' do
+      expect(TelegramBot::ManualSignalTrigger).to receive(:call).with(
+        chat_id: chat_id,
+        symbol: 'NIFTY',
+        option: :ce,
+        exchange: :nse
+      )
+
+      described_class.new(chat_id:, command: 'nifty ce').call
+    end
+
+    it 'delegates slash command variant to the manual trigger' do
+      expect(TelegramBot::ManualSignalTrigger).to receive(:call).with(
+        chat_id: chat_id,
+        symbol: 'BANKNIFTY',
+        option: :pe,
+        exchange: :nse
+      )
+
+      described_class.new(chat_id:, command: '/banknifty_pe').call
+    end
+
+    it 'routes sensex commands to the BSE exchange' do
+      expect(TelegramBot::ManualSignalTrigger).to receive(:call).with(
+        chat_id: chat_id,
+        symbol: 'SENSEX',
+        option: :ce,
+        exchange: :bse
+      )
+
+      described_class.new(chat_id:, command: 'sensex-ce').call
+    end
+
+    it 'falls back to unknown command message when pattern not matched' do
+      expect(TelegramBot::ManualSignalTrigger).not_to receive(:call)
+
+      described_class.new(chat_id:, command: '/unknown').call
+
+      expect(TelegramNotifier).to have_received(:send_message).with('❓ Unknown command: /unknown', chat_id: chat_id)
+    end
+  end
+end

--- a/spec/services/telegram_bot/manual_signal_trigger_spec.rb
+++ b/spec/services/telegram_bot/manual_signal_trigger_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TelegramBot::ManualSignalTrigger do
+  let(:chat_id) { 'chat-123' }
+  let!(:instrument) { create(:instrument, :nifty) }
+  let(:processor) { instance_double(AlertProcessors::Index, call: true) }
+
+  before do
+    allow_any_instance_of(Instrument).to receive(:quote_ltp).and_return(22_150.0)
+    allow_any_instance_of(Instrument).to receive(:ltp).and_return(22_150.0)
+    allow(TelegramNotifier).to receive(:send_chat_action)
+    allow(TelegramNotifier).to receive(:send_message)
+    allow(AlertProcessorFactory).to receive(:build).and_return(processor)
+  end
+
+  describe '.call' do
+    it 'creates an alert and delegates to the alert processor' do
+      expect do
+        described_class.call(chat_id:, symbol: 'NIFTY', option: :ce, exchange: :nse)
+      end.to change(Alert, :count).by(1)
+
+      alert = Alert.last
+
+      expect(alert.signal_type).to eq('long_entry')
+      expect(alert.instrument_type).to eq('index')
+      expect(AlertProcessorFactory).to have_received(:build).with(alert)
+      expect(TelegramNotifier).to have_received(:send_chat_action).with(hash_including(chat_id: chat_id))
+      expect(TelegramNotifier).to have_received(:send_message).with(/Manual NIFTY CE signal queued/, chat_id: chat_id)
+    end
+
+    it 'notifies when instrument lookup fails' do
+      expect(TelegramNotifier).to receive(:send_message).with(/instrument not configured/i, chat_id: chat_id)
+
+      result = described_class.call(chat_id:, symbol: 'SENSEX', option: :ce, exchange: :bse)
+
+      expect(result).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add CE/PE symbol maps in the Telegram command handler so manual option signals are recognised
- introduce a ManualSignalTrigger service that builds index alerts and reuses the existing processors
- cover the new behaviour with specs for the handler and trigger service

## Testing
- bundle exec rspec spec/services/telegram_bot/manual_signal_trigger_spec.rb spec/services/telegram_bot/command_handler_spec.rb *(fails: bundler cannot find `rspec`; requires bundle install which in turn needs Ruby 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68da6b5fdccc832aab196630fe27e5fb