### PR TITLE
Allow expiry-day options buying prompt guidance

### DIFF
--- a/app/services/market/prompt_builder.rb
+++ b/app/services/market/prompt_builder.rb
@@ -212,7 +212,7 @@ module Market
           If any of the below hold, output: "Decision Gate: AVOID – <reason>"
           - IV regime likely to compress (IV high and falling or post-event) 
           - VIX falling and price range-bound
-          - <48 hours to expiry without momentum; theta risk high
+          - <48 hours to expiry without momentum; theta risk high (expiry-day scalps allowed if momentum confirmed)
           - Wide spreads or low OI/volume at chosen strike
           - No clear directional edge on this timeframe
           Otherwise output: "Decision Gate: BUY – <reason>"


### PR DESCRIPTION
## Summary
- adjust the options buying prompt so expiry-day setups with confirmed momentum are not automatically avoided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ecb310bc832ab0b654f65c798563