### PR TITLE
fix(mcp): normalize tool arguments

### DIFF
--- a/app/services/mcp/handlers/call_tool.rb
+++ b/app/services/mcp/handlers/call_tool.rb
@@ -4,19 +4,31 @@ module Mcp
   module Handlers
     # Handler for executing a specific tool via MCP.
     class CallTool
+      class << self
+        private
+
+        def normalize_args(args)
+          raise ArgumentError, 'Expected Hash' unless args.is_a?(Hash)
+
+          args.deep_symbolize_keys
+        end
+      end
+
       def self.call(req, registry: ToolRegistry)
         params = req['params'] || {}
         name   = params['name']
-        args   = params['arguments'] || {}
+        args   = normalize_args(params['arguments'] || {})
 
         tool = registry.tools.find { |t| t.name == name }
         raise "Unknown tool: #{name}" unless tool
 
+        Rails.logger.info("[MCP] Tool=#{name} Args=#{args.inspect}")
+
         result = tool.execute(args)
         is_error =
           result.is_a?(Hash) &&
-            result.key?(:error) &&
-            result[:error].present?
+          result.key?(:error) &&
+          result[:error].present?
 
         {
           jsonrpc: '2.0',
@@ -28,6 +40,8 @@ module Mcp
           }
         }
       rescue StandardError => e
+        Rails.logger.error("[MCP ERROR] #{e.class}: #{e.message}")
+        Rails.logger.error(e.backtrace.first(5).join("\n")) if e.backtrace.present?
         {
           jsonrpc: '2.0',
           id: req['id'],

--- a/app/services/mcp/tools/analyze_trade.rb
+++ b/app/services/mcp/tools/analyze_trade.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that wraps the deterministic trade decision engine.
     class AnalyzeTrade
+      extend ExecutionHelpers
       def self.name
         'analyze_trade'
       end
@@ -25,7 +26,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         symbol = opts[:symbol].to_s
         expiry = opts[:expiry].presence
 

--- a/app/services/mcp/tools/backtest_strategy.rb
+++ b/app/services/mcp/tools/backtest_strategy.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for backtesting an options strategy via MCP.
     class BacktestStrategy
+      extend ExecutionHelpers
       def self.name
         'backtest_strategy'
       end
@@ -26,10 +27,12 @@ module Mcp
       end
 
       def self.execute(args)
+        opts = normalize_args!(name, args)
+
         {
           status: 'not_implemented',
           message: 'Backtest engine is not yet wired in MCP. Use historical data tools and external backtest if needed.',
-          params_received: args.slice('symbol', 'from_date', 'to_date').compact
+          params_received: opts.slice(:symbol, :from_date, :to_date).compact
         }
       end
     end

--- a/app/services/mcp/tools/close_trade.rb
+++ b/app/services/mcp/tools/close_trade.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for closing an open position on DhanHQ via MCP.
     class CloseTrade
+      extend ExecutionHelpers
       def self.name
         'close_trade'
       end
@@ -30,7 +31,7 @@ module Mcp
       def self.execute(args)
         return { error: 'Dhan not configured. Set DHAN_CLIENT_ID and complete login.' } unless dhan_configured?
 
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         payload = build_payload(opts)
 
         place_order(payload)

--- a/app/services/mcp/tools/execution_helpers.rb
+++ b/app/services/mcp/tools/execution_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mcp
+  module Tools
+    # Shared argument normalization/validation for MCP tools.
+    module ExecutionHelpers
+      private
+
+      def normalize_args!(tool_name, args)
+        raise ArgumentError, 'Expected Hash' unless args.is_a?(Hash)
+
+        normalized_args = args.deep_symbolize_keys
+        Rails.logger.info("[MCP] Tool=#{tool_name} Args=#{normalized_args.inspect}")
+        normalized_args
+      end
+    end
+  end
+end

--- a/app/services/mcp/tools/exit_position.rb
+++ b/app/services/mcp/tools/exit_position.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that exits an existing position via Orders::Executor (market order).
     class ExitPosition
+      extend ExecutionHelpers
       def self.name
         'exit_position'
       end
@@ -26,7 +27,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         security_id = opts[:security_id].to_s
         exchange_segment = opts[:exchange_segment].to_s
         reason = opts[:reason].presence || 'MCP_EXIT'

--- a/app/services/mcp/tools/explain_trade.rb
+++ b/app/services/mcp/tools/explain_trade.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for explaining a trade setup via MCP using LLM.
     class ExplainTrade
+      extend ExecutionHelpers
       def self.name
         'explain_trade'
       end
@@ -25,10 +26,11 @@ module Mcp
       end
 
       def self.execute(args)
-        query = args['query'] || args[:query]
+        opts = normalize_args!(name, args).with_indifferent_access
+        query = opts[:query]
         raise ArgumentError, 'query is required' if query.blank?
 
-        context = args['context'] || args[:context]
+        context = opts[:context]
         prompt = context.present? ? "#{query}\n\nContext: #{context}" : query
 
         answer = Openai::MessageProcessor.call(prompt, model: nil, system: nil)

--- a/app/services/mcp/tools/get_confluence_signal.rb
+++ b/app/services/mcp/tools/get_confluence_signal.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that computes the deterministic confluence signal from candles.
     class GetConfluenceSignal
+      extend ExecutionHelpers
       def self.name
         'get_confluence_signal'
       end
@@ -25,7 +26,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         symbol = opts[:symbol].to_s.upcase
         interval = opts[:interval].presence || '5'
 

--- a/app/services/mcp/tools/get_iv_rank.rb
+++ b/app/services/mcp/tools/get_iv_rank.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for computing IV rank (percentile bucketed) for an index option chain.
     class GetIvRank
+      extend ExecutionHelpers
       def self.name
         'get_iv_rank'
       end
@@ -25,7 +26,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         symbol = opts[:symbol].to_s.upcase
         expiry = opts[:expiry].presence
 

--- a/app/services/mcp/tools/get_key_levels.rb
+++ b/app/services/mcp/tools/get_key_levels.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that computes key levels deterministically from recent candles.
     class GetKeyLevels
+      extend ExecutionHelpers
       def self.name
         'get_key_levels'
       end
@@ -25,7 +26,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         symbol = opts[:symbol].to_s.upcase
         interval = opts[:interval].presence || '5'
 

--- a/app/services/mcp/tools/get_market_data.rb
+++ b/app/services/mcp/tools/get_market_data.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for fetching historical or intraday market data via MCP.
     class GetMarketData
+      extend ExecutionHelpers
       def self.name
         'get_market_data'
       end
@@ -25,8 +26,9 @@ module Mcp
       end
 
       def self.execute(args)
-        segment = (args['exchange_segment'] || args[:exchange_segment]).to_s
-        symbol = (args['symbol'] || args[:symbol]).to_s
+        opts = normalize_args!(name, args).with_indifferent_access
+        segment = opts[:exchange_segment].to_s
+        symbol = opts[:symbol].to_s
         raise ArgumentError, 'exchange_segment and symbol are required' if segment.blank? || symbol.blank?
 
         inst = DhanHQ::Models::Instrument.find(segment, symbol)

--- a/app/services/mcp/tools/get_market_sentiment.rb
+++ b/app/services/mcp/tools/get_market_sentiment.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for computing market sentiment (VIX, PCR, derived bias).
     class GetMarketSentiment
+      extend ExecutionHelpers
       def self.name
         'get_market_sentiment'
       end
@@ -24,7 +25,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         symbol = opts[:symbol].to_s.upcase
 
         instrument = resolve_instrument!(symbol)

--- a/app/services/mcp/tools/get_option_chain.rb
+++ b/app/services/mcp/tools/get_option_chain.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for retrieving an analyzed option chain via MCP.
     class GetOptionChain
+      extend ExecutionHelpers
       def self.name
         'get_option_chain'
       end
@@ -25,7 +26,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         instrument = resolve_instrument!(opts[:index])
         expiry = resolve_expiry!(instrument, opts[:expiry])
 

--- a/app/services/mcp/tools/get_positions.rb
+++ b/app/services/mcp/tools/get_positions.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for retrieving current open positions and holdings via MCP.
     class GetPositions
+      extend ExecutionHelpers
       def self.name
         'get_positions'
       end
@@ -21,7 +22,8 @@ module Mcp
         }
       end
 
-      def self.execute(_args)
+      def self.execute(args)
+        normalize_args!(name, args)
         unless ENV['DHAN_CLIENT_ID'].present? || ENV['CLIENT_ID'].present?
           return { error: 'Dhan not configured. Set DHAN_CLIENT_ID and complete login.' }
         end

--- a/app/services/mcp/tools/get_positions_v2.rb
+++ b/app/services/mcp/tools/get_positions_v2.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Production tool: returns enriched positions from Positions::ActiveCache and MarketCache/Orders::Analyzer.
     class GetPositionsV2
+      extend ExecutionHelpers
       def self.name
         'get_positions'
       end
@@ -21,7 +22,8 @@ module Mcp
         }
       end
 
-      def self.execute(_args)
+      def self.execute(args)
+        normalize_args!(name, args)
         positions = Positions::ActiveCache.all_positions
 
         formatted = positions.map { |pos| format_position(pos) }.compact

--- a/app/services/mcp/tools/manage_position.rb
+++ b/app/services/mcp/tools/manage_position.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that modifies an existing position via Trading::PositionManager.
     class ManagePosition
+      extend ExecutionHelpers
       def self.name
         'manage_position'
       end
@@ -31,7 +32,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         security_id = opts[:security_id].to_s
         exchange_segment = opts[:exchange_segment].to_s
         action = opts[:action].to_s

--- a/app/services/mcp/tools/place_order.rb
+++ b/app/services/mcp/tools/place_order.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that places a live or dry-run order via Orders::Gateway.
     class PlaceOrder
+      extend ExecutionHelpers
       def self.name
         'place_order'
       end
@@ -31,7 +32,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         security_id = opts[:security_id].to_s
         exchange_segment = opts[:exchange_segment].to_s
         transaction_type = opts[:transaction_type].to_s.upcase

--- a/app/services/mcp/tools/place_trade.rb
+++ b/app/services/mcp/tools/place_trade.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for placing a new trade order on DhanHQ via MCP.
     class PlaceTrade
+      extend ExecutionHelpers
       def self.name
         'place_trade'
       end
@@ -32,7 +33,7 @@ module Mcp
       def self.execute(args)
         return { error: 'Dhan not configured. Set DHAN_CLIENT_ID and complete login at /auth/dhan/login.' } unless dhan_configured?
 
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         payload = build_payload(opts)
 
         place_order(payload)

--- a/app/services/mcp/tools/resolve_derivative.rb
+++ b/app/services/mcp/tools/resolve_derivative.rb
@@ -5,6 +5,7 @@ module Mcp
     # Tool that deterministically maps an option contract request
     # to the exact Dhan tradable instrument identifiers using the scrip master.
     class ResolveDerivative
+      extend ExecutionHelpers
       def self.name
         'resolve_derivative'
       end
@@ -27,7 +28,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
 
         result = Trading::DerivativeResolver.new(
           symbol: opts[:symbol],

--- a/app/services/mcp/tools/scan_trade_setup.rb
+++ b/app/services/mcp/tools/scan_trade_setup.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for running the strategy scanner via MCP.
     class ScanTradeSetup
+      extend ExecutionHelpers
       def self.name
         'scan_trade_setup'
       end
@@ -27,7 +28,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         instrument = resolve_instrument!(opts[:index_symbol])
         expiry_date = resolve_expiry!(instrument, opts[:expiry_date])
 

--- a/app/services/mcp/tools/system_status.rb
+++ b/app/services/mcp/tools/system_status.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that returns current system / market readiness flags.
     class SystemStatus
+      extend ExecutionHelpers
       def self.name
         'system_status'
       end
@@ -21,7 +22,8 @@ module Mcp
         }
       end
 
-      def self.execute(_args)
+      def self.execute(args)
+        normalize_args!(name, args)
         now = Time.current
         market_open = market_open?(now)
         active_positions = Positions::ActiveCache.all_positions.count

--- a/spec/services/mcp/handlers/call_tool_spec.rb
+++ b/spec/services/mcp/handlers/call_tool_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mcp::Handlers::CallTool do
+  describe '.call' do
+    let(:tool_class) do
+      Class.new do
+        class << self
+          attr_reader :received_args
+
+          def name
+            'test_tool'
+          end
+
+          def execute(args)
+            @received_args = args
+            { ok: true }
+          end
+        end
+      end
+    end
+
+    let(:registry) do
+      Class.new do
+        define_singleton_method(:tools) { [tool_class] }
+      end
+    end
+
+    it 'deep-symbolizes tool arguments before execution' do
+      request = {
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'params' => {
+          'name' => 'test_tool',
+          'arguments' => {
+            'symbol' => 'NIFTY',
+            'filters' => { 'interval' => '5' }
+          }
+        }
+      }
+
+      response = described_class.call(request, registry: registry)
+
+      expect(response.dig(:result, :isError)).to be(false)
+      expect(tool_class.received_args).to eq(symbol: 'NIFTY', filters: { interval: '5' })
+    end
+
+    it 'returns an MCP error payload for non-hash arguments' do
+      request = {
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'params' => {
+          'name' => 'test_tool',
+          'arguments' => 'invalid'
+        }
+      }
+
+      response = described_class.call(request, registry: registry)
+
+      expect(response.dig(:result, :isError)).to be(true)
+      expect(response.dig(:result, :structuredContent, :error)).to eq('Expected Hash')
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
- MCP tools were forwarding raw argument hashes which caused kwargs/parameter mismatches (e.g. `UnrecognizedKwargsError: params`) when downstream services expected symbolized keyword args.
- Centralizing argument normalization prevents per-tool mistakes and avoids the call(params: args) anti-pattern.

### Description
- Deep-symbolize incoming `params['arguments']` in the central MCP dispatcher `Mcp::Handlers::CallTool` and add logging for tool invocations and handler errors.
- Add `Mcp::Tools::ExecutionHelpers` which enforces that tool arguments are a Hash, deep-symbolizes keys, and logs the normalized args.
- Update the MCP tool wrappers (most files under `app/services/mcp/tools/*`, including `AnalyzeTrade`, `GetMarketSentiment`, `PlaceOrder`, `ResolveDerivative`, `ScanTradeSetup`, etc.) to use `normalize_args!(name, args)` before reading values so tools consistently receive symbolized keys.
- Add unit coverage for the handler at `spec/services/mcp/handlers/call_tool_spec.rb` verifying deep symbolization and the non-hash-arguments guard.

### Testing
- Ran syntax check: `bundle exec ruby -c app/services/mcp/handlers/call_tool.rb app/services/mcp/tools/execution_helpers.rb spec/services/mcp/handlers/call_tool_spec.rb` which returned `Syntax OK`.
- Ran lint for the focused changes: `bundle exec rubocop app/services/mcp/handlers/call_tool.rb app/services/mcp/tools/execution_helpers.rb spec/services/mcp/handlers/call_tool_spec.rb` with no offenses in the inspected files.
- Attempted to run specs: `bundle exec rspec spec/services/mcp/handlers/call_tool_spec.rb spec/requests/mcp_trade_flow_spec.rb` but the run was blocked locally because PostgreSQL was not available on the default socket in this environment (connection error), so full request-spec verification could not complete here.
- `bundle install` completed successfully in this environment prior to running checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7731863c832a8b7f2d24ef0bcf70)