### PR TITLE
MCP: normalize `params:`-wrapped arguments, add ExecutionHelpers, and harden tool handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Available tools include: `get_holdings`, `get_positions`, `get_fund_limits`, `ge
 
 Full docs, argument shapes, and example `curl` calls: **[docs/MCP.md](docs/MCP.md)**.
 
+The HTTP MCP transport may wrap tool inputs inside a `params` envelope and attach `server_context`; the Dhan MCP tool definitions normalize that payload before validation so live tool calls do not fail on keyword mismatches.
+
 ## 🤖 AI Agents (orchestration layer)
 
 The app exposes an **AI agents orchestration layer** for trading intelligence: market analysis, options flow, trade proposals, position review, and operational Q&A. It uses the [chatwoot/ai-agents](https://github.com/chatwoot/ai-agents) gem.

--- a/app/services/dhan_mcp/account_tools.rb
+++ b/app/services/dhan_mcp/account_tools.rb
@@ -11,19 +11,41 @@ module DhanMcp
     private
 
     def define_fund_limits(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+
       @server.define_tool(
         name: 'get_fund_limits',
         description: 'Retrieve available funds, margins, and limits.',
         input_schema: { properties: {} }
-      ) { |**_| dhan(fmt) { ::DhanHQ::Models::Funds.fetch } }
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        if (err = validator.call('get_fund_limits', args))
+          fmt.call({ error: err })
+        else
+          dhan_call.call { ::DhanHQ::Models::Funds.fetch }
+        end
+      end
     end
 
     def define_edis_inquiry(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+
       @server.define_tool(
         name: 'get_edis_inquiry',
         description: 'Retrieve eDIS (electronic delivery instruction slip) inquiry status.',
         input_schema: { properties: {} }
-      ) { |**_| dhan(fmt) { ::DhanHQ::Models::Edis.inquire('ALL') } }
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        if (err = validator.call('get_edis_inquiry', args))
+          fmt.call({ error: err })
+        else
+          dhan_call.call { ::DhanHQ::Models::Edis.inquire('ALL') }
+        end
+      end
     end
   end
 end

--- a/app/services/dhan_mcp/base_tool.rb
+++ b/app/services/dhan_mcp/base_tool.rb
@@ -25,5 +25,10 @@ module DhanMcp
     def validate(tool_name, args)
       DhanMcp::ArgumentValidator.validate(tool_name, args)
     end
+
+    def normalized_args(params: nil, **kwargs)
+      payload = params.is_a?(Hash) ? params : kwargs
+      DhanMcp::ArgumentValidator.symbolize(payload).except(:server_context)
+    end
   end
 end

--- a/app/services/dhan_mcp/market_tools.rb
+++ b/app/services/dhan_mcp/market_tools.rb
@@ -15,6 +15,11 @@ module DhanMcp
     private
 
     def define_instrument(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+      resolver = method(:resolve_instrument)
+
       @server.define_tool(
         name: 'get_instrument',
         description: 'Resolve instrument by segment and symbol. ' \
@@ -27,17 +32,24 @@ module DhanMcp
           },
           required: %w[exchange_segment symbol]
         }
-      ) do |exchange_segment:, symbol:, **_|
-        args = { exchange_segment: exchange_segment, symbol: symbol }
-        if (err = validate('get_instrument', args))
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        exchange_segment = args[:exchange_segment]
+        symbol = args[:symbol]
+        if (err = validator.call('get_instrument', args))
           fmt.call({ error: err })
         else
-          dhan(fmt) { resolve_instrument(exchange_segment, symbol) }
+          dhan_call.call { resolver.call(exchange_segment, symbol) }
         end
       end
     end
 
     def define_historical_daily_data(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+      resolver = method(:resolve_instrument)
+
       @server.define_tool(
         name: 'get_historical_daily_data',
         description: 'Retrieve historical daily candle data.',
@@ -50,17 +62,26 @@ module DhanMcp
           },
           required: %w[exchange_segment symbol from_date to_date]
         }
-      ) do |exchange_segment:, symbol:, from_date:, to_date:, **_|
-        args = { exchange_segment: exchange_segment, symbol: symbol, from_date: from_date, to_date: to_date }
-        if (err = validate('get_historical_daily_data', args))
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        exchange_segment = args[:exchange_segment]
+        symbol = args[:symbol]
+        from_date = args[:from_date]
+        to_date = args[:to_date]
+        if (err = validator.call('get_historical_daily_data', args))
           fmt.call({ error: err })
         else
-          dhan(fmt) { resolve_instrument(exchange_segment, symbol).daily(from_date: from_date, to_date: to_date) }
+          dhan_call.call { resolver.call(exchange_segment, symbol).daily(from_date: from_date, to_date: to_date) }
         end
       end
     end
 
     def define_intraday_minute_data(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+      resolver = method(:resolve_instrument)
+
       @server.define_tool(
         name: 'get_intraday_minute_data',
         description: 'Retrieve intraday minute candle data.',
@@ -74,15 +95,20 @@ module DhanMcp
           },
           required: %w[exchange_segment symbol from_date to_date]
         }
-      ) do |exchange_segment:, symbol:, from_date:, to_date:, interval: '1', **_|
-        args = { exchange_segment: exchange_segment, symbol: symbol, from_date: from_date, to_date: to_date, interval: interval }
-        if (err = validate('get_intraday_minute_data', args))
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        exchange_segment = args[:exchange_segment]
+        symbol = args[:symbol]
+        from_date = args[:from_date]
+        to_date = args[:to_date]
+        interval = args.fetch(:interval, '1')
+        if (err = validator.call('get_intraday_minute_data', args))
           fmt.call({ error: err })
         else
           from_ts = from_date.to_s.include?(' ') ? from_date : "#{from_date} 09:15:00"
           to_ts = to_date.to_s.include?(' ') ? to_date : "#{to_date} 15:30:00"
-          dhan(fmt) do
-            resolve_instrument(exchange_segment, symbol).intraday(
+          dhan_call.call do
+            resolver.call(exchange_segment, symbol).intraday(
               from_date: from_ts, to_date: to_ts, interval: interval
             )
           end
@@ -91,6 +117,11 @@ module DhanMcp
     end
 
     def define_market_ohlc(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+      resolver = method(:resolve_instrument)
+
       @server.define_tool(
         name: 'get_market_ohlc',
         description: 'Retrieve current OHLC for a security.',
@@ -101,17 +132,24 @@ module DhanMcp
           },
           required: %w[exchange_segment symbol]
         }
-      ) do |exchange_segment:, symbol:, **_|
-        args = { exchange_segment: exchange_segment, symbol: symbol }
-        if (err = validate('get_market_ohlc', args))
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        exchange_segment = args[:exchange_segment]
+        symbol = args[:symbol]
+        if (err = validator.call('get_market_ohlc', args))
           fmt.call({ error: err })
         else
-          dhan(fmt) { resolve_instrument(exchange_segment, symbol).ohlc }
+          dhan_call.call { resolver.call(exchange_segment, symbol).ohlc }
         end
       end
     end
 
     def define_option_chain(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+      resolver = method(:resolve_instrument)
+
       @server.define_tool(
         name: 'get_option_chain',
         description: 'Retrieve full option chain for an underlying.',
@@ -123,17 +161,25 @@ module DhanMcp
           },
           required: %w[exchange_segment symbol expiry]
         }
-      ) do |exchange_segment:, symbol:, expiry:, **_|
-        args = { exchange_segment: exchange_segment, symbol: symbol, expiry: expiry }
-        if (err = validate('get_option_chain', args))
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        exchange_segment = args[:exchange_segment]
+        symbol = args[:symbol]
+        expiry = args[:expiry]
+        if (err = validator.call('get_option_chain', args))
           fmt.call({ error: err })
         else
-          dhan(fmt) { resolve_instrument(exchange_segment, symbol).option_chain(expiry: expiry) }
+          dhan_call.call { resolver.call(exchange_segment, symbol).option_chain(expiry: expiry) }
         end
       end
     end
 
     def define_expiry_list(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+      resolver = method(:resolve_instrument)
+
       @server.define_tool(
         name: 'get_expiry_list',
         description: 'Retrieve expiry dates for an underlying. ' \
@@ -145,12 +191,14 @@ module DhanMcp
           },
           required: %w[exchange_segment symbol]
         }
-      ) do |exchange_segment:, symbol:, **_|
-        args = { exchange_segment: exchange_segment, symbol: symbol }
-        if (err = validate('get_expiry_list', args))
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        exchange_segment = args[:exchange_segment]
+        symbol = args[:symbol]
+        if (err = validator.call('get_expiry_list', args))
           fmt.call({ error: err })
         else
-          dhan(fmt) { resolve_instrument(exchange_segment, symbol).expiry_list }
+          dhan_call.call { resolver.call(exchange_segment, symbol).expiry_list }
         end
       end
     end

--- a/app/services/dhan_mcp/order_tools.rb
+++ b/app/services/dhan_mcp/order_tools.rb
@@ -14,14 +14,29 @@ module DhanMcp
     private
 
     def define_order_list(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+
       @server.define_tool(
         name: 'get_order_list',
         description: "Retrieve the full list of orders (today's and historical).",
         input_schema: { properties: {} }
-      ) { |**_| dhan(fmt) { ::DhanHQ::Models::Order.all } }
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        if (err = validator.call('get_order_list', args))
+          fmt.call({ error: err })
+        else
+          dhan_call.call { ::DhanHQ::Models::Order.all }
+        end
+      end
     end
 
     def define_order_by_id(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+
       @server.define_tool(
         name: 'get_order_by_id',
         description: 'Retrieve details for a specific order by Dhan order ID.',
@@ -29,16 +44,22 @@ module DhanMcp
           properties: { order_id: { type: 'string', description: 'The Dhan order ID' } },
           required: ['order_id']
         }
-      ) do |order_id:, **_|
-        if (err = validate('get_order_by_id', { order_id: order_id }))
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        order_id = args[:order_id]
+        if (err = validator.call('get_order_by_id', args))
           fmt.call({ error: err })
         else
-          dhan(fmt) { ::DhanHQ::Models::Order.find(order_id) }
+          dhan_call.call { ::DhanHQ::Models::Order.find(order_id) }
         end
       end
     end
 
     def define_order_by_correlation_id(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+
       @server.define_tool(
         name: 'get_order_by_correlation_id',
         description: 'Retrieve order details by correlation ID.',
@@ -46,16 +67,22 @@ module DhanMcp
           properties: { correlation_id: { type: 'string', description: 'The correlation ID' } },
           required: ['correlation_id']
         }
-      ) do |correlation_id:, **_|
-        if (err = validate('get_order_by_correlation_id', { correlation_id: correlation_id }))
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        correlation_id = args[:correlation_id]
+        if (err = validator.call('get_order_by_correlation_id', args))
           fmt.call({ error: err })
         else
-          dhan(fmt) { ::DhanHQ::Models::Order.find_by(correlation: correlation_id) }
+          dhan_call.call { ::DhanHQ::Models::Order.find_by(correlation: correlation_id) }
         end
       end
     end
 
     def define_trade_book(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+
       @server.define_tool(
         name: 'get_trade_book',
         description: 'Retrieve executed trades for a specific order.',
@@ -63,16 +90,22 @@ module DhanMcp
           properties: { order_id: { type: 'string', description: 'The Dhan order ID' } },
           required: ['order_id']
         }
-      ) do |order_id:, **_|
-        if (err = validate('get_trade_book', { order_id: order_id }))
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        order_id = args[:order_id]
+        if (err = validator.call('get_trade_book', args))
           fmt.call({ error: err })
         else
-          dhan(fmt) { ::DhanHQ::Models::Trade.find_by(order_id: order_id) }
+          dhan_call.call { ::DhanHQ::Models::Trade.find_by(order_id: order_id) }
         end
       end
     end
 
     def define_trade_history(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+
       @server.define_tool(
         name: 'get_trade_history',
         description: 'Retrieve trade history between dates (paginated).',
@@ -84,12 +117,15 @@ module DhanMcp
           },
           required: %w[from_date to_date]
         }
-      ) do |from_date:, to_date:, page_number: 0, **_|
-        args = { from_date: from_date, to_date: to_date, page_number: page_number }
-        if (err = validate('get_trade_history', args))
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        from_date = args[:from_date]
+        to_date = args[:to_date]
+        page_number = args.fetch(:page_number, 0)
+        if (err = validator.call('get_trade_history', args))
           fmt.call({ error: err })
         else
-          dhan(fmt) { ::DhanHQ::Models::Trade.history(from_date: from_date, to_date: to_date, page: page_number) }
+          dhan_call.call { ::DhanHQ::Models::Trade.history(from_date: from_date, to_date: to_date, page: page_number) }
         end
       end
     end

--- a/app/services/dhan_mcp/portfolio_tools.rb
+++ b/app/services/dhan_mcp/portfolio_tools.rb
@@ -11,19 +11,41 @@ module DhanMcp
     private
 
     def define_holdings(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+
       @server.define_tool(
         name: 'get_holdings',
         description: 'Retrieve current portfolio holdings.',
         input_schema: { properties: {} }
-      ) { |**_| dhan(fmt) { ::DhanHQ::Models::Holding.all } }
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        if (err = validator.call('get_holdings', args))
+          fmt.call({ error: err })
+        else
+          dhan_call.call { ::DhanHQ::Models::Holding.all }
+        end
+      end
     end
 
     def define_positions(fmt)
+      normalize = method(:normalized_args)
+      validator = method(:validate)
+      dhan_call = ->(&block) { dhan(fmt, &block) }
+
       @server.define_tool(
         name: 'get_positions',
         description: 'Retrieve current open positions (intraday and delivery).',
         input_schema: { properties: {} }
-      ) { |**_| dhan(fmt) { ::DhanHQ::Models::Position.all } }
+      ) do |params: nil, **kwargs|
+        args = normalize.call(params: params, **kwargs)
+        if (err = validator.call('get_positions', args))
+          fmt.call({ error: err })
+        else
+          dhan_call.call { ::DhanHQ::Models::Position.all }
+        end
+      end
     end
   end
 end

--- a/app/services/mcp/handlers/call_tool.rb
+++ b/app/services/mcp/handlers/call_tool.rb
@@ -4,19 +4,31 @@ module Mcp
   module Handlers
     # Handler for executing a specific tool via MCP.
     class CallTool
+      class << self
+        private
+
+        def normalize_args(args)
+          raise ArgumentError, 'Expected Hash' unless args.is_a?(Hash)
+
+          args.deep_symbolize_keys
+        end
+      end
+
       def self.call(req, registry: ToolRegistry)
         params = req['params'] || {}
         name   = params['name']
-        args   = params['arguments'] || {}
+        args   = normalize_args(params['arguments'] || {})
 
         tool = registry.tools.find { |t| t.name == name }
         raise "Unknown tool: #{name}" unless tool
 
+        Rails.logger.info("[MCP] Tool=#{name} Args=#{args.inspect}")
+
         result = tool.execute(args)
         is_error =
           result.is_a?(Hash) &&
-            result.key?(:error) &&
-            result[:error].present?
+          result.key?(:error) &&
+          result[:error].present?
 
         {
           jsonrpc: '2.0',
@@ -28,6 +40,8 @@ module Mcp
           }
         }
       rescue StandardError => e
+        Rails.logger.error("[MCP ERROR] #{e.class}: #{e.message}")
+        Rails.logger.error(e.backtrace.first(5).join("\n")) if e.backtrace.present?
         {
           jsonrpc: '2.0',
           id: req['id'],

--- a/app/services/mcp/tools/analyze_trade.rb
+++ b/app/services/mcp/tools/analyze_trade.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that wraps the deterministic trade decision engine.
     class AnalyzeTrade
+      extend ExecutionHelpers
       def self.name
         'analyze_trade'
       end
@@ -25,7 +26,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         symbol = opts[:symbol].to_s
         expiry = opts[:expiry].presence
 

--- a/app/services/mcp/tools/backtest_strategy.rb
+++ b/app/services/mcp/tools/backtest_strategy.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for backtesting an options strategy via MCP.
     class BacktestStrategy
+      extend ExecutionHelpers
       def self.name
         'backtest_strategy'
       end
@@ -26,10 +27,12 @@ module Mcp
       end
 
       def self.execute(args)
+        opts = normalize_args!(name, args)
+
         {
           status: 'not_implemented',
           message: 'Backtest engine is not yet wired in MCP. Use historical data tools and external backtest if needed.',
-          params_received: args.slice('symbol', 'from_date', 'to_date').compact
+          params_received: opts.slice(:symbol, :from_date, :to_date).compact
         }
       end
     end

--- a/app/services/mcp/tools/close_trade.rb
+++ b/app/services/mcp/tools/close_trade.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for closing an open position on DhanHQ via MCP.
     class CloseTrade
+      extend ExecutionHelpers
       def self.name
         'close_trade'
       end
@@ -30,7 +31,7 @@ module Mcp
       def self.execute(args)
         return { error: 'Dhan not configured. Set DHAN_CLIENT_ID and complete login.' } unless dhan_configured?
 
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         payload = build_payload(opts)
 
         place_order(payload)

--- a/app/services/mcp/tools/execution_helpers.rb
+++ b/app/services/mcp/tools/execution_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mcp
+  module Tools
+    # Shared argument normalization/validation for MCP tools.
+    module ExecutionHelpers
+      private
+
+      def normalize_args!(tool_name, args)
+        raise ArgumentError, 'Expected Hash' unless args.is_a?(Hash)
+
+        normalized_args = args.deep_symbolize_keys
+        Rails.logger.info("[MCP] Tool=#{tool_name} Args=#{normalized_args.inspect}")
+        normalized_args
+      end
+    end
+  end
+end

--- a/app/services/mcp/tools/exit_position.rb
+++ b/app/services/mcp/tools/exit_position.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that exits an existing position via Orders::Executor (market order).
     class ExitPosition
+      extend ExecutionHelpers
       def self.name
         'exit_position'
       end
@@ -26,7 +27,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         security_id = opts[:security_id].to_s
         exchange_segment = opts[:exchange_segment].to_s
         reason = opts[:reason].presence || 'MCP_EXIT'

--- a/app/services/mcp/tools/explain_trade.rb
+++ b/app/services/mcp/tools/explain_trade.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for explaining a trade setup via MCP using LLM.
     class ExplainTrade
+      extend ExecutionHelpers
       def self.name
         'explain_trade'
       end
@@ -25,10 +26,11 @@ module Mcp
       end
 
       def self.execute(args)
-        query = args['query'] || args[:query]
+        opts = normalize_args!(name, args).with_indifferent_access
+        query = opts[:query]
         raise ArgumentError, 'query is required' if query.blank?
 
-        context = args['context'] || args[:context]
+        context = opts[:context]
         prompt = context.present? ? "#{query}\n\nContext: #{context}" : query
 
         answer = Openai::MessageProcessor.call(prompt, model: nil, system: nil)

--- a/app/services/mcp/tools/get_confluence_signal.rb
+++ b/app/services/mcp/tools/get_confluence_signal.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that computes the deterministic confluence signal from candles.
     class GetConfluenceSignal
+      extend ExecutionHelpers
       def self.name
         'get_confluence_signal'
       end
@@ -25,7 +26,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         symbol = opts[:symbol].to_s.upcase
         interval = opts[:interval].presence || '5'
 

--- a/app/services/mcp/tools/get_iv_rank.rb
+++ b/app/services/mcp/tools/get_iv_rank.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for computing IV rank (percentile bucketed) for an index option chain.
     class GetIvRank
+      extend ExecutionHelpers
       def self.name
         'get_iv_rank'
       end
@@ -25,7 +26,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         symbol = opts[:symbol].to_s.upcase
         expiry = opts[:expiry].presence
 

--- a/app/services/mcp/tools/get_key_levels.rb
+++ b/app/services/mcp/tools/get_key_levels.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that computes key levels deterministically from recent candles.
     class GetKeyLevels
+      extend ExecutionHelpers
       def self.name
         'get_key_levels'
       end
@@ -25,7 +26,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         symbol = opts[:symbol].to_s.upcase
         interval = opts[:interval].presence || '5'
 

--- a/app/services/mcp/tools/get_market_data.rb
+++ b/app/services/mcp/tools/get_market_data.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for fetching historical or intraday market data via MCP.
     class GetMarketData
+      extend ExecutionHelpers
       def self.name
         'get_market_data'
       end
@@ -25,8 +26,9 @@ module Mcp
       end
 
       def self.execute(args)
-        segment = (args['exchange_segment'] || args[:exchange_segment]).to_s
-        symbol = (args['symbol'] || args[:symbol]).to_s
+        opts = normalize_args!(name, args).with_indifferent_access
+        segment = opts[:exchange_segment].to_s
+        symbol = opts[:symbol].to_s
         raise ArgumentError, 'exchange_segment and symbol are required' if segment.blank? || symbol.blank?
 
         inst = DhanHQ::Models::Instrument.find(segment, symbol)

--- a/app/services/mcp/tools/get_market_sentiment.rb
+++ b/app/services/mcp/tools/get_market_sentiment.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for computing market sentiment (VIX, PCR, derived bias).
     class GetMarketSentiment
+      extend ExecutionHelpers
       def self.name
         'get_market_sentiment'
       end
@@ -24,7 +25,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         symbol = opts[:symbol].to_s.upcase
 
         instrument = resolve_instrument!(symbol)

--- a/app/services/mcp/tools/get_option_chain.rb
+++ b/app/services/mcp/tools/get_option_chain.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for retrieving an analyzed option chain via MCP.
     class GetOptionChain
+      extend ExecutionHelpers
       def self.name
         'get_option_chain'
       end
@@ -25,7 +26,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         instrument = resolve_instrument!(opts[:index])
         expiry = resolve_expiry!(instrument, opts[:expiry])
 

--- a/app/services/mcp/tools/get_positions.rb
+++ b/app/services/mcp/tools/get_positions.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for retrieving current open positions and holdings via MCP.
     class GetPositions
+      extend ExecutionHelpers
       def self.name
         'get_positions'
       end
@@ -21,7 +22,8 @@ module Mcp
         }
       end
 
-      def self.execute(_args)
+      def self.execute(args)
+        normalize_args!(name, args)
         unless ENV['DHAN_CLIENT_ID'].present? || ENV['CLIENT_ID'].present?
           return { error: 'Dhan not configured. Set DHAN_CLIENT_ID and complete login.' }
         end

--- a/app/services/mcp/tools/get_positions_v2.rb
+++ b/app/services/mcp/tools/get_positions_v2.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Production tool: returns enriched positions from Positions::ActiveCache and MarketCache/Orders::Analyzer.
     class GetPositionsV2
+      extend ExecutionHelpers
       def self.name
         'get_positions'
       end
@@ -21,7 +22,8 @@ module Mcp
         }
       end
 
-      def self.execute(_args)
+      def self.execute(args)
+        normalize_args!(name, args)
         positions = Positions::ActiveCache.all_positions
 
         formatted = positions.map { |pos| format_position(pos) }.compact

--- a/app/services/mcp/tools/manage_position.rb
+++ b/app/services/mcp/tools/manage_position.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that modifies an existing position via Trading::PositionManager.
     class ManagePosition
+      extend ExecutionHelpers
       def self.name
         'manage_position'
       end
@@ -31,7 +32,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         security_id = opts[:security_id].to_s
         exchange_segment = opts[:exchange_segment].to_s
         action = opts[:action].to_s

--- a/app/services/mcp/tools/place_order.rb
+++ b/app/services/mcp/tools/place_order.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that places a live or dry-run order via Orders::Gateway.
     class PlaceOrder
+      extend ExecutionHelpers
       def self.name
         'place_order'
       end
@@ -31,7 +32,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         security_id = opts[:security_id].to_s
         exchange_segment = opts[:exchange_segment].to_s
         transaction_type = opts[:transaction_type].to_s.upcase

--- a/app/services/mcp/tools/place_trade.rb
+++ b/app/services/mcp/tools/place_trade.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for placing a new trade order on DhanHQ via MCP.
     class PlaceTrade
+      extend ExecutionHelpers
       def self.name
         'place_trade'
       end
@@ -32,7 +33,7 @@ module Mcp
       def self.execute(args)
         return { error: 'Dhan not configured. Set DHAN_CLIENT_ID and complete login at /auth/dhan/login.' } unless dhan_configured?
 
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         payload = build_payload(opts)
 
         place_order(payload)

--- a/app/services/mcp/tools/resolve_derivative.rb
+++ b/app/services/mcp/tools/resolve_derivative.rb
@@ -5,6 +5,7 @@ module Mcp
     # Tool that deterministically maps an option contract request
     # to the exact Dhan tradable instrument identifiers using the scrip master.
     class ResolveDerivative
+      extend ExecutionHelpers
       def self.name
         'resolve_derivative'
       end
@@ -27,7 +28,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
 
         result = Trading::DerivativeResolver.new(
           symbol: opts[:symbol],

--- a/app/services/mcp/tools/scan_trade_setup.rb
+++ b/app/services/mcp/tools/scan_trade_setup.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool for running the strategy scanner via MCP.
     class ScanTradeSetup
+      extend ExecutionHelpers
       def self.name
         'scan_trade_setup'
       end
@@ -27,7 +28,7 @@ module Mcp
       end
 
       def self.execute(args)
-        opts = args.with_indifferent_access
+        opts = normalize_args!(name, args).with_indifferent_access
         instrument = resolve_instrument!(opts[:index_symbol])
         expiry_date = resolve_expiry!(instrument, opts[:expiry_date])
 

--- a/app/services/mcp/tools/system_status.rb
+++ b/app/services/mcp/tools/system_status.rb
@@ -4,6 +4,7 @@ module Mcp
   module Tools
     # Tool that returns current system / market readiness flags.
     class SystemStatus
+      extend ExecutionHelpers
       def self.name
         'system_status'
       end
@@ -21,7 +22,8 @@ module Mcp
         }
       end
 
-      def self.execute(_args)
+      def self.execute(args)
+        normalize_args!(name, args)
         now = Time.current
         market_open = market_open?(now)
         active_positions = Positions::ActiveCache.all_positions.count

--- a/docs/updates/2026-03-20.md
+++ b/docs/updates/2026-03-20.md
@@ -1,0 +1,7 @@
+# 2026-03-20
+
+## MCP tool argument compatibility fix
+
+- Fixed the Streamable HTTP Dhan MCP tool layer to accept MCP gem `params:`-wrapped arguments.
+- Normalized tool arguments before validation/execution and ignored framework-provided `server_context` metadata.
+- Added regression coverage for `tools/call` requests hitting `get_market_ohlc` and `get_positions` so keyword argument mismatches do not regress.

--- a/docs/updates/README.md
+++ b/docs/updates/README.md
@@ -12,6 +12,7 @@ This directory tracks progress and changes to the project in markdown files.
 
 | Date       | File            | Summary |
 | ---------- | --------------- | ------- |
+| 2026-03-20 | [2026-03-20.md] | Fix MCP `params:` argument wrapping and `server_context` leakage |
 | 2026-03-12 | [2026-03-12.md] | Enforce centralized PLACE_ORDER order gateway invariant |
 | 2026-03-08 | [2026-03-08.md] | **Major Architectural Refactoring (SOLID & Clean Code)** |
 | 2026-03-03 | [2026-03-03.md] | Fix TA background loop in rake context |
@@ -27,3 +28,5 @@ This directory tracks progress and changes to the project in markdown files.
 [SPEC_STUBBING_AUDIT.md]: ./SPEC_STUBBING_AUDIT.md
 
 [2026-03-12.md]: ./2026-03-12.md
+
+[2026-03-20.md]: ./2026-03-20.md

--- a/spec/services/dhan_mcp_service_spec.rb
+++ b/spec/services/dhan_mcp_service_spec.rb
@@ -27,6 +27,53 @@ RSpec.describe DhanMcpService, :mcp, type: :service do
       end
     end
 
+    it 'handles params-wrapped arguments for a market tool call' do
+      server = described_class.build_server
+      body = {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'get_market_ohlc',
+          arguments: {
+            exchange_segment: 'IDX_I',
+            symbol: 'NIFTY'
+          }
+        }
+      }.to_json
+
+      result = server.handle_json(body)
+      parsed = JSON.parse(result)
+      text = parsed.dig('result', 'content', 0, 'text').to_s
+
+      expect(parsed['jsonrpc']).to eq('2.0')
+      expect(text).not_to include('UnrecognizedKwargsError')
+      expect(text).not_to include('unknown keyword: :params')
+      expect(text).not_to include('Unexpected argument(s): server_context')
+    end
+
+    it 'handles params-wrapped calls for no-argument tools without kwargs errors' do
+      server = described_class.build_server
+      body = {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'get_positions',
+          arguments: {}
+        }
+      }.to_json
+
+      result = server.handle_json(body)
+      parsed = JSON.parse(result)
+      text = parsed.dig('result', 'content', 0, 'text').to_s
+
+      expect(parsed['jsonrpc']).to eq('2.0')
+      expect(text).not_to include('UnrecognizedKwargsError')
+      expect(text).not_to include('unknown keyword: :params')
+      expect(text).not_to include('Unexpected argument(s): server_context')
+    end
+
     it 'returns valid JSON-RPC for unknown method' do
       server = described_class.build_server
       body = { jsonrpc: '2.0', id: 99, method: 'unknown/method' }.to_json

--- a/spec/services/mcp/handlers/call_tool_spec.rb
+++ b/spec/services/mcp/handlers/call_tool_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mcp::Handlers::CallTool do
+  describe '.call' do
+    let(:tool_class) do
+      Class.new do
+        class << self
+          attr_reader :received_args
+
+          def name
+            'test_tool'
+          end
+
+          def execute(args)
+            @received_args = args
+            { ok: true }
+          end
+        end
+      end
+    end
+
+    let(:registry) do
+      Class.new do
+        define_singleton_method(:tools) { [tool_class] }
+      end
+    end
+
+    it 'deep-symbolizes tool arguments before execution' do
+      request = {
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'params' => {
+          'name' => 'test_tool',
+          'arguments' => {
+            'symbol' => 'NIFTY',
+            'filters' => { 'interval' => '5' }
+          }
+        }
+      }
+
+      response = described_class.call(request, registry: registry)
+
+      expect(response.dig(:result, :isError)).to be(false)
+      expect(tool_class.received_args).to eq(symbol: 'NIFTY', filters: { interval: '5' })
+    end
+
+    it 'returns an MCP error payload for non-hash arguments' do
+      request = {
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'params' => {
+          'name' => 'test_tool',
+          'arguments' => 'invalid'
+        }
+      }
+
+      response = described_class.call(request, registry: registry)
+
+      expect(response.dig(:result, :isError)).to be(true)
+      expect(response.dig(:result, :structuredContent, :error)).to eq('Expected Hash')
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

- Fix failures when the Streamable HTTP MCP transport wraps tool inputs in a `params` envelope and attaches framework `server_context`, which caused keyword-arg mismatches and `UnrecognizedKwargsError` in tool calls.
- Centralize argument normalization and logging for MCP tools to reduce repetitive checks and make validation deterministic before execution.
- Prevent uncaught exceptions and improve observability for MCP tool execution paths.

### Description

- Added a shared helper `Mcp::Tools::ExecutionHelpers` with `normalize_args!` and wired many MCP tool classes to `extend ExecutionHelpers` so tools deep-symbolize and log incoming args before use. 
- Added `normalized_args` to `DhanMcp::BaseTool` and updated all `DhanMcp::*` tool definitions to accept `params:`-wrapped calls, strip `server_context`, validate via `ArgumentValidator`, and use a `dhan_call` wrapper for consistent execution.
- Updated `Mcp::Handlers::CallTool` to deep-symbolize/validate `arguments`, log tool calls, and log errors/backtrace on exceptions; adjusted the MCP tool implementations to consume normalized args (use `normalize_args!` / `with_indifferent_access`).
- Added docs and changelog entry `docs/updates/2026-03-20.md` and updated `README.md` to explain the `params` envelope handling and compatibility fix.
- Added/updated specs to cover the new behavior: `spec/services/dhan_mcp_service_spec.rb` tests for `tools/call` with `params` wrapping and new handler unit tests in `spec/services/mcp/handlers/call_tool_spec.rb`.

### Testing

- Ran `rspec spec/services/dhan_mcp_service_spec.rb` which includes regression tests for `tools/call` invoking `get_market_ohlc` and `get_positions`, and those specs passed. 
- Ran `rspec spec/services/mcp/handlers/call_tool_spec.rb` which verifies deep-symbolization and error handling for non-hash arguments, and those specs passed. 
- New tests exercise the `params:` wrapping and `server_context` stripping to prevent prior keyword-argument errors and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7731863c832a8b7f2d24ef0bcf70)