### PR TITLE
fix(mcp): normalize wrapped action tool arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Available tools include: `get_holdings`, `get_positions`, `get_fund_limits`, `ge
 
 Full docs, argument shapes, and example `curl` calls: **[docs/MCP.md](docs/MCP.md)**.
 
-The HTTP MCP transport may wrap tool inputs inside a `params` envelope and attach `server_context`; the Dhan MCP tool definitions normalize that payload before validation so live tool calls do not fail on keyword mismatches.
+The HTTP MCP transport may wrap tool inputs inside a `params` envelope and attach `server_context`; both the production MCP dispatcher and the Dhan MCP tool definitions normalize that payload before validation so live tool calls do not fail on keyword mismatches.
 
 ## 🤖 AI Agents (orchestration layer)
 

--- a/app/services/mcp/handlers/call_tool.rb
+++ b/app/services/mcp/handlers/call_tool.rb
@@ -10,14 +10,29 @@ module Mcp
         def normalize_args(args)
           raise ArgumentError, 'Expected Hash' unless args.is_a?(Hash)
 
-          args.deep_symbolize_keys
+          payload = args.with_indifferent_access
+          if payload[:params].is_a?(Hash)
+            payload = payload[:params].merge(payload.except(:params, :server_context))
+          end
+
+          payload.except(:server_context).deep_symbolize_keys
+        end
+
+        def extract_args(params)
+          return {} if params.blank?
+
+          if params.key?('arguments') || params.key?(:arguments)
+            normalize_args(params['arguments'] || params[:arguments] || {})
+          else
+            normalize_args(params.except('name', :name, 'server_context', :server_context))
+          end
         end
       end
 
       def self.call(req, registry: ToolRegistry)
         params = req['params'] || {}
         name   = params['name']
-        args   = normalize_args(params['arguments'] || {})
+        args   = extract_args(params)
 
         tool = registry.tools.find { |t| t.name == name }
         raise "Unknown tool: #{name}" unless tool

--- a/docs/updates/2026-03-20.md
+++ b/docs/updates/2026-03-20.md
@@ -4,4 +4,5 @@
 
 - Fixed the Streamable HTTP Dhan MCP tool layer to accept MCP gem `params:`-wrapped arguments.
 - Normalized tool arguments before validation/execution and ignored framework-provided `server_context` metadata.
+- Extended the production `/mcp` tool-call handler to unwrap `arguments.params`, ignore `server_context`, and accept direct argument payloads from ChatGPT Actions style requests.
 - Added regression coverage for `tools/call` requests hitting `get_market_ohlc` and `get_positions` so keyword argument mismatches do not regress.

--- a/spec/requests/mcp_trade_flow_spec.rb
+++ b/spec/requests/mcp_trade_flow_spec.rb
@@ -137,5 +137,53 @@ RSpec.describe 'MCP trade flow', :mcp do
     expect(place_result['blocked']).to eq(false)
     expect(place_result['payload']['exchange_segment']).to eq(resolver_result.exchange_segment)
   end
-end
 
+  it 'accepts params-wrapped analyze_trade arguments from ChatGPT Actions style payloads' do
+    expiry_date = Date.iso8601('2026-03-26')
+
+    trade_result = Trading::TradeDecisionEngine::Result.new(
+      proceed: true,
+      symbol: 'NIFTY',
+      direction: 'CE',
+      expiry: expiry_date.to_s,
+      selected_strike: { strike_price: 22_450, last_price: 150.0 },
+      iv_rank: 35.0,
+      regime: 'normal',
+      chain_analysis: { trend: 'up' },
+      spot: 200.0,
+      reason: nil,
+      timestamp: Time.current
+    )
+
+    allow(Trading::TradeDecisionEngine).to receive(:call)
+      .with(symbol: 'NIFTY', expiry: expiry_date.to_s)
+      .and_return(trade_result)
+
+    body = {
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: {
+        name: 'analyze_trade',
+        arguments: {
+          params: {
+            symbol: 'NIFTY',
+            expiry: expiry_date.to_s,
+            server_context: { request_id: 'abc123' }
+          },
+          server_context: { transport: 'openai_actions' }
+        }
+      }
+    }
+
+    post '/mcp',
+         params: body.to_json,
+         headers: { 'Content-Type' => 'application/json' }.merge(MCP_ACCEPT).merge(MCP_AUTH)
+
+    expect(response).to have_http_status(:ok)
+    json = response.parsed_body
+    expect(json.dig('result', 'isError')).to eq(false)
+    expect(json.dig('result', 'structuredContent', 'symbol')).to eq('NIFTY')
+    expect(json.dig('result', 'structuredContent', 'expiry')).to eq(expiry_date.to_s)
+  end
+end

--- a/spec/services/mcp/handlers/call_tool_spec.rb
+++ b/spec/services/mcp/handlers/call_tool_spec.rb
@@ -46,10 +46,49 @@ RSpec.describe Mcp::Handlers::CallTool do
       expect(tool_class.received_args).to eq(symbol: 'NIFTY', filters: { interval: '5' })
     end
 
-    it 'returns an MCP error payload for non-hash arguments' do
+    it 'unwraps params-wrapped arguments and drops server_context metadata' do
       request = {
         'jsonrpc' => '2.0',
         'id' => 2,
+        'params' => {
+          'name' => 'test_tool',
+          'arguments' => {
+            'params' => {
+              'symbol' => 'NIFTY',
+              'server_context' => { 'request_id' => 'abc123' }
+            },
+            'server_context' => { 'transport' => 'openai_actions' }
+          }
+        }
+      }
+
+      response = described_class.call(request, registry: registry)
+
+      expect(response.dig(:result, :isError)).to be(false)
+      expect(tool_class.received_args).to eq(symbol: 'NIFTY')
+    end
+
+    it 'accepts direct tool arguments when arguments is omitted' do
+      request = {
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'params' => {
+          'name' => 'test_tool',
+          'symbol' => 'NIFTY',
+          'server_context' => { 'transport' => 'openai_actions' }
+        }
+      }
+
+      response = described_class.call(request, registry: registry)
+
+      expect(response.dig(:result, :isError)).to be(false)
+      expect(tool_class.received_args).to eq(symbol: 'NIFTY')
+    end
+
+    it 'returns an MCP error payload for non-hash arguments' do
+      request = {
+        'jsonrpc' => '2.0',
+        'id' => 4,
         'params' => {
           'name' => 'test_tool',
           'arguments' => 'invalid'


### PR DESCRIPTION
### Motivation
- ChatGPT Actions and similar MCP transports can wrap tool inputs under an extra `params` envelope and attach `server_context` metadata which caused production `/mcp` tool calls (e.g. `analyze_trade`) to fail validation or raise keyword-argument errors.

### Description
- Updated production MCP tool-call handler in `app/services/mcp/handlers/call_tool.rb` to unwrap `arguments.params`, drop `server_context`, and accept direct argument keys when `arguments` is omitted via `extract_args` + enhanced `normalize_args` logic.
- Added unit/regression coverage in `spec/services/mcp/handlers/call_tool_spec.rb` to exercise normal args, params-wrapped payloads, direct-argument fallback, and non-hash rejection, and added an end-to-end request spec in `spec/requests/mcp_trade_flow_spec.rb` that exercises a ChatGPT Actions–style `analyze_trade` payload.
- Documented the compatibility behavior in `README.md` and extended the `docs/updates/2026-03-20.md` changelog entry to reflect the production `/mcp` compatibility fix.

### Testing
- Ran Ruby syntax checks: `ruby -c app/services/mcp/handlers/call_tool.rb` and `ruby -c spec/services/mcp/handlers/call_tool_spec.rb` and `ruby -c spec/requests/mcp_trade_flow_spec.rb`, which all returned syntax OK.
- Attempted dependency verification with `bundle check` but the container environment did not have the project's gems installed so full `rspec` could not be executed (warning: bundle not installed). 
- The changes include regression specs that will run under the normal CI/dev environment with `bundle exec rspec` (not run in this container).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd95812174832a98b7754f4ced4ea9)