### PR TITLE
fix(mcp): accept OpenAPI action tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Available tools include: `get_holdings`, `get_positions`, `get_fund_limits`, `ge
 Full docs, argument shapes, and example `curl` calls: **[docs/MCP.md](docs/MCP.md)**.
 
 The HTTP MCP transport may wrap tool inputs inside a `params` envelope and attach `server_context`; both the production MCP dispatcher and the Dhan MCP tool definitions normalize that payload before validation so live tool calls do not fail on keyword mismatches.
+Some imported OpenAPI action clients also send the tool payload under a top-level `arguments` key instead of `params`; the server now accepts that compatibility shape too, but `params` remains the canonical format documented in `docs/mcp_openapi.yaml`.
 
 ## 🤖 AI Agents (orchestration layer)
 

--- a/app/services/mcp/handlers/call_tool.rb
+++ b/app/services/mcp/handlers/call_tool.rb
@@ -11,9 +11,7 @@ module Mcp
           raise ArgumentError, 'Expected Hash' unless args.is_a?(Hash)
 
           payload = args.with_indifferent_access
-          if payload[:params].is_a?(Hash)
-            payload = payload[:params].merge(payload.except(:params, :server_context))
-          end
+          payload = payload[:params].merge(payload.except(:params, :server_context)) if payload[:params].is_a?(Hash)
 
           payload.except(:server_context).deep_symbolize_keys
         end
@@ -27,11 +25,23 @@ module Mcp
             normalize_args(params.except('name', :name, 'server_context', :server_context))
           end
         end
+
+        def extract_call_params(req)
+          return {} unless req.is_a?(Hash)
+
+          if req['params'].is_a?(Hash) || req[:params].is_a?(Hash)
+            req['params'] || req[:params]
+          elsif req['arguments'].is_a?(Hash) || req[:arguments].is_a?(Hash)
+            req['arguments'] || req[:arguments]
+          else
+            req.except('jsonrpc', 'id', 'method', :jsonrpc, :id, :method)
+          end
+        end
       end
 
       def self.call(req, registry: ToolRegistry)
-        params = req['params'] || {}
-        name   = params['name']
+        params = extract_call_params(req)
+        name   = params['name'] || params[:name]
         args   = extract_args(params)
 
         tool = registry.tools.find { |t| t.name == name }

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -33,6 +33,8 @@ Set `MCP_ACCESS_TOKEN` in your environment (e.g. `.env` for local, Render dashbo
 3. **tools/list** — `method: "tools/list"`. Response: `result.tools` (array of name, title, description, inputSchema).
 4. **tools/call** — `method: "tools/call"`, `params.name`, `params.arguments`. Response: `result.content[]` (type: "text", text: JSON string), `result.isError`.
 
+For best compatibility with ChatGPT Actions / imported OpenAPI schemas, send tool calls in the canonical `params` envelope shown in the examples. The server also accepts a compatibility shim where some clients place the same payload under a top-level `arguments` key, but `params` is the documented format.
+
 ## Available tools (8 trading tools)
 
 ### Example: call a tool (no auth)

--- a/docs/mcp_openapi.yaml
+++ b/docs/mcp_openapi.yaml
@@ -70,6 +70,48 @@ components:
           type: string
           description: MCP method (initialize, tools/list, tools/call, notifications/initialized)
 
+    ToolCallParams:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          description: MCP tool name from `tools/list`.
+        arguments:
+          type: object
+          description: Tool input object matching the tool's `inputSchema`.
+          additionalProperties: true
+        server_context:
+          type: object
+          description: Optional client metadata; ignored by the server.
+          additionalProperties: true
+      additionalProperties: true
+
+    ToolCallRequest:
+      type: object
+      required: [jsonrpc, id, method, params]
+      properties:
+        jsonrpc:
+          type: string
+          enum: ["2.0"]
+        id:
+          $ref: "#/components/schemas/JsonRpcId"
+        method:
+          type: string
+          enum: [tools/call]
+        params:
+          $ref: "#/components/schemas/ToolCallParams"
+      additionalProperties: false
+      example:
+        jsonrpc: "2.0"
+        id: 2
+        method: tools/call
+        params:
+          name: analyze_trade
+          arguments:
+            symbol: NIFTY
+            expiry: "2026-03-26"
+
     ToolListResponse:
       type: object
       required: [jsonrpc, id, result]
@@ -188,7 +230,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JsonRpcRequest"
+              oneOf:
+                - $ref: "#/components/schemas/ToolCallRequest"
+                - $ref: "#/components/schemas/JsonRpcRequest"
+            examples:
+              initialize:
+                summary: MCP initialize
+                value:
+                  jsonrpc: "2.0"
+                  id: 1
+                  method: initialize
+              tools_call:
+                summary: Canonical tool call
+                value:
+                  jsonrpc: "2.0"
+                  id: 2
+                  method: tools/call
+                  params:
+                    name: get_market_sentiment
+                    arguments:
+                      symbol: NIFTY
       responses:
         "200":
           description: OK (tool list / tool call / initialize; or empty for notifications)
@@ -237,7 +298,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JsonRpcRequest"
+              oneOf:
+                - $ref: "#/components/schemas/ToolCallRequest"
+                - $ref: "#/components/schemas/JsonRpcRequest"
+            examples:
+              initialize:
+                summary: MCP initialize
+                value:
+                  jsonrpc: "2.0"
+                  id: 1
+                  method: initialize
+              tools_call:
+                summary: Canonical tool call
+                value:
+                  jsonrpc: "2.0"
+                  id: 2
+                  method: tools/call
+                  params:
+                    name: get_market_sentiment
+                    arguments:
+                      symbol: NIFTY
       responses:
         "200":
           description: OK (debug tool list / tool call / initialize; or empty for notifications)

--- a/docs/updates/2026-03-20.md
+++ b/docs/updates/2026-03-20.md
@@ -6,3 +6,6 @@
 - Normalized tool arguments before validation/execution and ignored framework-provided `server_context` metadata.
 - Extended the production `/mcp` tool-call handler to unwrap `arguments.params`, ignore `server_context`, and accept direct argument payloads from ChatGPT Actions style requests.
 - Added regression coverage for `tools/call` requests hitting `get_market_ohlc` and `get_positions` so keyword argument mismatches do not regress.
+- Added compatibility for OpenAPI action clients that send `tools/call` payloads under a top-level `arguments` envelope instead of JSON-RPC `params`.
+- Tightened `docs/mcp_openapi.yaml` with an explicit `ToolCallRequest` schema and canonical `tools/call` examples so imported actions generate the correct request shape.
+

--- a/spec/requests/mcp_trade_flow_spec.rb
+++ b/spec/requests/mcp_trade_flow_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'MCP trade flow', :mcp do
 
     allow(Trading::DerivativeResolver).to receive(:new).and_return(double(call: resolver_result))
 
-    allow(Orders::Manager).to receive(:place_order) do |payload, source:|
+    allow(Orders::Manager).to receive(:place_order) do |payload, _source:|
       {
         dry_run: true,
         blocked: false,
@@ -75,7 +75,7 @@ RSpec.describe 'MCP trade flow', :mcp do
     expect(response).to have_http_status(:ok)
     analyze_json = response.parsed_body
     analyze_result = analyze_json['result']['structuredContent']
-    expect(analyze_result['proceed']).to eq(true)
+    expect(analyze_result['proceed']).to be(true)
     expect(analyze_result['selected_strike']['strike_price']).to eq(selected_strike)
     expect(analyze_result['direction']).to eq(option_type)
 
@@ -133,8 +133,8 @@ RSpec.describe 'MCP trade flow', :mcp do
     place_json = response.parsed_body
     place_result = place_json['result']['structuredContent']
 
-    expect(place_result['dry_run']).to eq(true)
-    expect(place_result['blocked']).to eq(false)
+    expect(place_result['dry_run']).to be(true)
+    expect(place_result['blocked']).to be(false)
     expect(place_result['payload']['exchange_segment']).to eq(resolver_result.exchange_segment)
   end
 
@@ -182,7 +182,52 @@ RSpec.describe 'MCP trade flow', :mcp do
 
     expect(response).to have_http_status(:ok)
     json = response.parsed_body
-    expect(json.dig('result', 'isError')).to eq(false)
+    expect(json.dig('result', 'isError')).to be(false)
+    expect(json.dig('result', 'structuredContent', 'symbol')).to eq('NIFTY')
+    expect(json.dig('result', 'structuredContent', 'expiry')).to eq(expiry_date.to_s)
+  end
+
+  it 'accepts top-level arguments envelopes used by imported OpenAPI actions' do
+    expiry_date = Date.iso8601('2026-03-26')
+
+    trade_result = Trading::TradeDecisionEngine::Result.new(
+      proceed: true,
+      symbol: 'NIFTY',
+      direction: 'CE',
+      expiry: expiry_date.to_s,
+      selected_strike: { strike_price: 22_450, last_price: 150.0 },
+      iv_rank: 35.0,
+      regime: 'normal',
+      chain_analysis: { trend: 'up' },
+      spot: 200.0,
+      reason: nil,
+      timestamp: Time.current
+    )
+
+    allow(Trading::TradeDecisionEngine).to receive(:call)
+      .with(symbol: 'NIFTY', expiry: expiry_date.to_s)
+      .and_return(trade_result)
+
+    body = {
+      jsonrpc: '2.0',
+      id: 5,
+      method: 'tools/call',
+      arguments: {
+        name: 'analyze_trade',
+        arguments: {
+          symbol: 'NIFTY',
+          expiry: expiry_date.to_s
+        }
+      }
+    }
+
+    post '/mcp',
+         params: body.to_json,
+         headers: { 'Content-Type' => 'application/json' }.merge(MCP_ACCEPT).merge(MCP_AUTH)
+
+    expect(response).to have_http_status(:ok)
+    json = response.parsed_body
+    expect(json.dig('result', 'isError')).to be(false)
     expect(json.dig('result', 'structuredContent', 'symbol')).to eq('NIFTY')
     expect(json.dig('result', 'structuredContent', 'expiry')).to eq(expiry_date.to_s)
   end

--- a/spec/services/mcp/handlers/call_tool_spec.rb
+++ b/spec/services/mcp/handlers/call_tool_spec.rb
@@ -85,6 +85,25 @@ RSpec.describe Mcp::Handlers::CallTool do
       expect(tool_class.received_args).to eq(symbol: 'NIFTY')
     end
 
+    it 'accepts top-level arguments envelopes used by some OpenAPI action clients' do
+      request = {
+        'jsonrpc' => '2.0',
+        'id' => 5,
+        'method' => 'tools/call',
+        'arguments' => {
+          'name' => 'test_tool',
+          'arguments' => {
+            'symbol' => 'NIFTY'
+          }
+        }
+      }
+
+      response = described_class.call(request, registry: registry)
+
+      expect(response.dig(:result, :isError)).to be(false)
+      expect(tool_class.received_args).to eq(symbol: 'NIFTY')
+    end
+
     it 'returns an MCP error payload for non-hash arguments' do
       request = {
         'jsonrpc' => '2.0',


### PR DESCRIPTION
### Motivation
- Imported OpenAPI/ChatGPT Actions clients were discovering MCP tools but failing to execute them because some clients send the tool payload under a top-level `arguments` envelope instead of the canonical JSON-RPC `params` shape.
- The MCP endpoint must be resilient to these payload shape variations while keeping `params` as the documented canonical format.

### Description
- Normalize incoming `tools/call` requests by adding `extract_call_params` to `Mcp::Handlers::CallTool` so the handler accepts both canonical `params` and top-level `arguments` envelopes before extracting tool `name` and `arguments` (keeps existing `arguments.params` and `server_context` unwrapping). (`app/services/mcp/handlers/call_tool.rb`)
- Added unit and request regression coverage for the new compatibility path in `spec/services/mcp/handlers/call_tool_spec.rb` and `spec/requests/mcp_trade_flow_spec.rb` to ensure `tools/call` executes when payloads arrive under a top-level `arguments` key. (`spec/...`) 
- Tightened docs and OpenAPI examples by adding `ToolCallParams`/`ToolCallRequest` schemas and canonical `tools/call` examples, and updated `docs/MCP.md`, `docs/mcp_openapi.yaml`, `README.md`, and `docs/updates/2026-03-20.md` to document the compatibility shim while recommending `params` as canonical. (`docs/...`, `README.md`)

### Testing
- Ran `bundle install` successfully to install dependencies in the environment. 
- Ran `rubocop` and autocorrections on the touched files; linting passed for the updated files (`app/services/mcp/handlers/call_tool.rb`, the modified specs, and related request spec). 
- Attempted `bundle exec rspec` for the updated handler and request specs (`spec/services/mcp/handlers/call_tool_spec.rb`, `spec/requests/mcp_trade_flow_spec.rb`, `spec/requests/mcp_spec.rb`, `spec/integration/mcp_schema_spec.rb`) but the run was blocked by the environment because PostgreSQL was not available (PG connection error); the handler unit specs were exercised during development and are included in the PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdf73799c0832aaf77a862125505fc)