### PR TITLE
fix(mcp): unify request body schema for OpenAI Actions import

### DIFF
--- a/docs/mcp_openapi.yaml
+++ b/docs/mcp_openapi.yaml
@@ -7,8 +7,8 @@ info:
     Endpoints are JSON-RPC 2.0 over HTTP POST.
 
 servers:
-  - url: http://localhost:5002
-    description: Local dev (replace with your deployed base URL)
+  - url: https://algo-trading-api.onrender.com
+    description: Production deployment base URL
 
 security:
   - bearerAuth: []
@@ -98,7 +98,7 @@ components:
           $ref: "#/components/schemas/JsonRpcId"
         method:
           type: string
-          enum: [tools/call]
+          enum: ["tools/call"]
         params:
           $ref: "#/components/schemas/ToolCallParams"
       additionalProperties: false
@@ -230,9 +230,31 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
-                - $ref: "#/components/schemas/ToolCallRequest"
-                - $ref: "#/components/schemas/JsonRpcRequest"
+              type: object
+              required: [jsonrpc, method]
+              properties:
+                jsonrpc:
+                  type: string
+                  enum: ["2.0"]
+                id:
+                  oneOf:
+                    - type: integer
+                    - type: string
+                method:
+                  type: string
+                  description: initialize | tools/list | tools/call | notifications/initialized
+                params:
+                  type: object
+                  additionalProperties: true
+              additionalProperties: true
+              example:
+                jsonrpc: "2.0"
+                id: 1
+                method: tools/call
+                params:
+                  name: get_market_sentiment
+                  arguments:
+                    symbol: NIFTY
             examples:
               initialize:
                 summary: MCP initialize
@@ -298,9 +320,31 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
-                - $ref: "#/components/schemas/ToolCallRequest"
-                - $ref: "#/components/schemas/JsonRpcRequest"
+              type: object
+              required: [jsonrpc, method]
+              properties:
+                jsonrpc:
+                  type: string
+                  enum: ["2.0"]
+                id:
+                  oneOf:
+                    - type: integer
+                    - type: string
+                method:
+                  type: string
+                  description: initialize | tools/list | tools/call | notifications/initialized
+                params:
+                  type: object
+                  additionalProperties: true
+              additionalProperties: true
+              example:
+                jsonrpc: "2.0"
+                id: 1
+                method: tools/call
+                params:
+                  name: get_market_sentiment
+                  arguments:
+                    symbol: NIFTY
             examples:
               initialize:
                 summary: MCP initialize


### PR DESCRIPTION
### Motivation
- OpenAI Actions rejects OpenAPI request bodies that use a root-level `oneOf`, which caused the MCP endpoints to be skipped during import. 
- The published server URL in the spec pointed to `http://localhost:5002` instead of the deployed HTTPS base URL. 
- A small enum quoting inconsistency (`tools/call` unquoted) could cause downstream tool/schema consumers to misinterpret the value.

### Description
- Replaced the root-level `oneOf` requestBody schema for both `/mcp` and `/mcp/debug` with a single object schema that requires `jsonrpc` and `method` and accepts a flexible `params` object while keeping `additionalProperties: true` in `docs/mcp_openapi.yaml`.
- Updated the `servers` entry to `https://algo-trading-api.onrender.com` to reflect the deployed HTTPS base URL in `docs/mcp_openapi.yaml`.
- Quoted the `"tools/call"` enum value in the reusable `ToolCallRequest` schema to be a valid YAML string enum in `docs/mcp_openapi.yaml`.
- Kept existing response schemas and examples intact and added a canonical request example to the unified request body schema.

### Testing
- Validated the YAML parses successfully with `ruby -e 'require "yaml"; YAML.load_file("docs/mcp_openapi.yaml"); puts "YAML OK"'`, which returned `YAML OK`.
- Performed a local spec file diff verification to confirm only the intended changes in `docs/mcp_openapi.yaml` were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdfd08f5bc832ab99d787716672c5b)