### PR TITLE
Make paper trading reachable and self-consistent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,30 @@ GLOBAL_ALLOC_PCT=20
 # probability and margin are configured per account via PaperAccount#config,
 # not by env vars.
 PAPER_TRADING=false
+
+# ── LLM backend ──────────────────────────────────────────────────────────
+# Which service answers chat requests from Openai::ChatRouter (the screener,
+# portfolio/position analysers and market commentary all go through it).
+# Leave blank for OpenAI; set to ollama_cloud to use the keys below. The flag
+# is ignored unless at least one key is present, so a half-finished rollout
+# cannot take the AI layer down.
+LLM_BACKEND=
+
+# Ollama Cloud — up to five keys, tried in order (https://ollama.com/settings/keys).
+# A key that returns 401/403/402/429/5xx is quarantined for five minutes and
+# the next one is used; see Llm::KeyRotator.
+OLLAMA_API_KEY_1=
+OLLAMA_API_KEY_2=
+OLLAMA_API_KEY_3=
+OLLAMA_API_KEY_4=
+OLLAMA_API_KEY_5=
+
+# Ollama Cloud speaks the OpenAI-compatible API and RubyLLM posts to
+# {base}/chat/completions, so the base must carry the /v1 or every call 404s.
+# Local Ollama: http://localhost:11434/v1
+OLLAMA_API_BASE=https://ollama.com/v1
+OLLAMA_DEFAULT_MODEL=qwen3-coder:480b-cloud
+
+# Per-attempt HTTP behaviour. Key rotation happens above these retries.
+LLM_REQUEST_TIMEOUT=120
+LLM_MAX_RETRIES=2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,23 @@ of what this repo already does. Don't re-open them without a concrete reason.
 - **`PAPER_TRADING=true`** routes `Orders::Gateway` to `Paper::Exchange`. Paper
   mode bypasses `PLACE_ORDER`/`LIVE_TRADING` on purpose: nothing reaches the
   broker, so those gates have nothing to protect.
+- **Never pre-check `Orders::Gateway.place_order_enabled?` before placing.** The
+  gateway routes to the paper book *before* it consults those gates, so a caller
+  that decides "blocked" on its own behalf silently makes paper mode
+  unreachable. Call the gateway and branch on the result.
 - Paper state lives in `paper_accounts` / `paper_orders` / `paper_positions`
   (single account, like `DhanAccessToken`), never in the live `orders` table —
   a simulated fill must never be readable as a real position.
+- **The read side must follow the write side.** In paper mode
+  `AlertProcessors::Base#available_balance` and `#dhan_positions` serve the
+  paper book (`Paper::Positions.dhan_shaped`, in the broker's key shape). Sizing
+  or guarding against the live book during a paper run stacks duplicate entries
+  and leaves the daily-loss cap reading zero.
 - **Resting orders and super-order legs are driven by the feed.** `live:feed`
   has to be running or a limit/stop will never fill and marks will go stale.
+  `Paper::FeedSubscriber` subscribes each instrument as it is traded and
+  restores the open book on feed start, so a strike picked at signal time is
+  ticked without anyone listing it in `SYMBOLS`.
 - Distinct from `DHAN_DRY_RUN`, which is the SDK suppressing requests. Paper
   mode simulates fills, margin, positions and P&L with real charges.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,21 @@ of what this repo already does. Don't re-open them without a concrete reason.
   `Paper::FeedSubscriber` subscribes each instrument as it is traded and
   restores the open book on feed start, so a strike picked at signal time is
   ticked without anyone listing it in `SYMBOLS`.
+- **The tick stream is the book's only clock.** `Paper::DayRollover` (expire
+  DAY orders, drop flat positions, clear last session's realised P&L) and
+  `Paper::EodSquareOff` (close INTRADAY at 15:15 IST; MARGIN and CNC are
+  carry-forward and stay open) both hang off it, lazily and idempotently,
+  because this app has no scheduler. `live:paper_roll` / `live:paper_eod` force
+  them. Day scoping of the position view is the rollover's job — never a
+  timestamp filter, which would hide a legitimate carry-forward position.
+- **Exit management reads `Positions::Source`**, which serves the paper book in
+  paper mode, so the existing `Positions::Manager` → `Orders::RiskManager` →
+  `Orders::Executor` stack manages simulated positions too. Paper positions
+  carry `costPrice` and `drvExpiryDate` because that stack reads them.
+- **CNC lives in two places.** A delivery position is in the position book only
+  on its trade date and in holdings from T+1, so exit logic checks
+  `dhan_positions` then falls back to `dhan_holdings`. eDIS never runs in paper
+  mode — it authorises a real depository debit.
 - Distinct from `DHAN_DRY_RUN`, which is the SDK suppressing requests. Paper
   mode simulates fills, margin, positions and P&L with real charges.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,27 @@ of what this repo already does. Don't re-open them without a concrete reason.
 - Distinct from `DHAN_DRY_RUN`, which is the SDK suppressing requests. Paper
   mode simulates fills, margin, positions and P&L with real charges.
 
+## LLM layer
+
+- **`Openai::ChatRouter` is the switch.** Every chat caller goes through it, so
+  the backend is env-selected (`LLM_BACKEND=ollama_cloud`), never per-caller.
+- **`Llm::KeyRotator` owns Ollama Cloud auth.** Up to five keys from
+  `OLLAMA_API_KEY_1..5`, quarantined 5 minutes on 401/403/402/429/5xx. Never
+  rotate on `BadRequestError`/`ModelNotFoundError` — those fail identically on
+  every key and would burn the pool over a caller-side bug.
+- **Never set `ollama_api_key` globally.** Keys are bound per request via
+  `RubyLLM.context`; the feed thread and web requests share this process, so a
+  global `RubyLLM.configure` swaps the key underneath a concurrent caller.
+- `OLLAMA_API_BASE` must end in `/v1` — RubyLLM posts to
+  `{base}/chat/completions`.
+- Cloud model ids are absent from RubyLLM's registry, so chats need
+  `provider: :ollama, assume_model_exists: true`.
+- **`Llm::Tools::*` wrap `AI::Tools::*`**, never reimplement them — one copy of
+  the DhanHQ plumbing. `use_new_acts_as` is set in `config/application.rb`
+  because the railtie reads it before app initializers run.
+- `ai-agents` must stay on a line allowing `ruby_llm >= 1.16`; earlier ruby_llm
+  sent no `Authorization` header at all and could not reach Ollama Cloud.
+
 ## Critical rules
 
 - **DhanHQ only** — no Delta Exchange references anywhere in this repo

--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,15 @@ gem 'openai', require: false
 gem 'ruby-openai', require: false
 
 # Multi-agent AI orchestration (https://github.com/chatwoot/ai-agents)
-gem 'ai-agents'
+# Pinned to a line that allows ruby_llm >= 1.14: 0.9.x pinned ruby_llm ~> 1.9.1,
+# which predates the Ollama provider sending an Authorization header and so
+# could not reach Ollama Cloud at all.
+gem 'ai-agents', '~> 0.12'
+
+# Unified LLM client (https://rubyllm.com). Used directly for the Ollama Cloud
+# path; `ai-agents` also builds on it. >= 1.16 for the authenticated Ollama
+# provider.
+gem 'ruby_llm', '~> 1.16'
 
 gem 'technical-analysis'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,8 +88,8 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    ai-agents (0.9.1)
-      ruby_llm (~> 1.9.1)
+    ai-agents (0.12.0)
+      ruby_llm (~> 1.14)
     ast (2.4.2)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -274,7 +274,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.4)
+    marcel (1.2.1)
     matrix (0.4.3)
     mcp (0.6.0)
       json-schema (>= 4.1)
@@ -452,17 +452,17 @@ GEM
       faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-technical-analysis (1.0.4)
-    ruby_llm (1.9.2)
+    ruby_llm (1.16.0)
       base64
       event_stream_parser (~> 1)
       faraday (>= 1.10.0)
       faraday-multipart (>= 1)
       faraday-net_http (>= 1)
       faraday-retry (>= 1)
-      marcel (~> 1.0)
-      ruby_llm-schema (~> 0.2.1)
+      marcel (~> 1)
+      ruby_llm-schema (~> 0)
       zeitwerk (~> 2)
-    ruby_llm-schema (0.2.5)
+    ruby_llm-schema (0.4.0)
     ruby_parser (3.21.1)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -563,7 +563,7 @@ PLATFORMS
 DEPENDENCIES
   DhanHQ (~> 3.2, >= 3.2.1)
   activerecord-import
-  ai-agents
+  ai-agents (~> 0.12)
   benchmark-ips
   bindata
   bootsnap
@@ -598,6 +598,7 @@ DEPENDENCIES
   rubocop-rspec_rails
   ruby-openai
   ruby-technical-analysis
+  ruby_llm (~> 1.16)
   rubycritic
   shoulda-matchers
   simplecov

--- a/README.md
+++ b/README.md
@@ -227,7 +227,13 @@ simulated exchange over **real market data**:
   slippage applied **against the taker** — buys fill higher, sells lower.
 - **Resting orders.** A non-marketable limit and an un-elected stop rest, then
   fill when a later tick reaches them. This is driven by the market feed, so
-  `bin/rails live:feed` must be running for resting orders to work.
+  `bin/rails live:feed` must be running for resting orders to work. The feed
+  subscribes each instrument as the book trades it and re-subscribes anything
+  still working on start-up, so an option strike chosen at signal time is
+  ticked without being listed in `SYMBOLS`.
+- **Its own capital and its own positions.** Sizing and every guard — entry
+  dedupe, flips, exits, the daily-loss cap — read the paper book while
+  `PAPER_TRADING=true`, not the live account.
 - **Super orders.** Once the entry fills, a tick through the target or stop
   closes the position, whichever comes first.
 - **Virtual capital and margin.** Orders are rejected when the book cannot fund

--- a/README.md
+++ b/README.md
@@ -330,6 +330,48 @@ The app exposes an **AI agents orchestration layer** for trading intelligence: m
 
 Full docs, configuration, request/response shapes, and Ruby usage: **[docs/AI_AGENTS.md](docs/AI_AGENTS.md)**.
 
+## 🧠 LLM backend (OpenAI or Ollama Cloud)
+
+Chat requests go through `Openai::ChatRouter`, so the backend is an env change
+rather than a code change in each of its callers (the screener, the portfolio
+and position analysers, the market commentary).
+
+```bash
+LLM_BACKEND=ollama_cloud     # blank = OpenAI
+OLLAMA_API_KEY_1=...         # up to OLLAMA_API_KEY_5
+OLLAMA_API_BASE=https://ollama.com/v1
+OLLAMA_DEFAULT_MODEL=qwen3-coder:480b-cloud
+
+bin/rails llm:keys           # which keys are configured / quarantined
+bin/rails llm:check_keys     # probe each key against the API
+bin/rails llm:ask PROMPT="what is NIFTY's PCR right now?"
+bin/rails llm:propose SYMBOL=NIFTY
+```
+
+**Key rotation.** One key is a single point of failure — rate limits are per
+key, and a revoked one takes the AI layer down. `Llm::KeyRotator` tries up to
+five in order; a key answering 401/403/402/429/5xx is quarantined for five
+minutes and the next is used. A bad request or an unknown model is *not*
+rotated on: it would fail identically on every key, so it raises rather than
+burning the pool. Each attempt runs in its own `RubyLLM.context`, an isolated
+copy of the config, because the market-feed thread and web requests share this
+process and a global `RubyLLM.configure` would swap the key underneath a
+concurrent caller.
+
+Two safety properties are deliberate: the `LLM_BACKEND` flag is ignored unless
+at least one key is present, and exhausting the pool falls back to OpenAI — so
+neither a half-finished rollout nor an Ollama outage stops a screener run.
+
+**Base URL.** Ollama Cloud speaks the OpenAI-compatible API and RubyLLM posts
+to `{base}/chat/completions`, so `OLLAMA_API_BASE` must carry the `/v1` or
+every call 404s. Local Ollama is `http://localhost:11434/v1`.
+
+`Llm::TradingAgent` is the single-model counterpart to `AI::TradeBrain`, with
+tool access to live option chains, candles, funds, positions and sentiment —
+thin wrappers over the existing `AI::Tools::*`, not a second copy of them. Like
+every other path here it stops at a proposal: `Strategy::Validator` and
+`Orders::Gateway` decide what executes.
+
 ## 🏗️ Architecture
 
 ### Core Components

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ shape is identical to a live placement.
 ```bash
 PAPER_TRADING=true bin/rails s
 bin/rails live:paper_book    # positions, working orders, P&L and charges
+bin/rails live:paper_eod     # square off intraday positions now
+bin/rails live:paper_roll    # roll the book onto the current session
 bin/rails live:paper_reset   # reset the book to its starting capital
 ```
 
@@ -235,7 +237,12 @@ simulated exchange over **real market data**:
   dedupe, flips, exits, the daily-loss cap — read the paper book while
   `PAPER_TRADING=true`, not the live account.
 - **Super orders.** Once the entry fills, a tick through the target or stop
-  closes the position, whichever comes first.
+  closes the position, whichever comes first. A `trailing_jump` ratchets the
+  stop in whole jumps as price advances, and never gives it back.
+- **Session boundaries.** INTRADAY positions are squared off at 15:15 IST as the
+  broker would; MARGIN and CNC carry forward. On the next session the book is
+  rolled: DAY orders expire, flat positions are dropped and last session's
+  realised P&L is cleared, so the daily-loss guard counts today only.
 - **Virtual capital and margin.** Orders are rejected when the book cannot fund
   them; margin is blocked on placement and released on fill or cancel.
 - **Real Dhan charges** per fill, including the STT asymmetry (sell-side for

--- a/app/services/alert_processors/base.rb
+++ b/app/services/alert_processors/base.rb
@@ -87,6 +87,27 @@ module AlertProcessors
         end
     end
 
+    # Delivery holdings on whichever book this run trades.
+    #
+    # A CNC buy shows in the *position* book only on the day it trades; from
+    # T+1 the broker reports it as a holding and the position book shows
+    # nothing. Swing and long-term exits keyed to positions alone therefore
+    # stopped finding the position they were meant to close, on every day but
+    # the first.
+    #
+    # @return [Array<Hash>]
+    def dhan_holdings
+      @dhan_holdings ||=
+        if Paper::Broker.enabled?
+          Paper::Positions.dhan_holdings
+        else
+          DhanHQ::Models::Holding.all.map(&:attributes)
+        end
+    rescue StandardError => e
+      Rails.logger.warn("[#{self.class.name}] holdings fetch failed: #{e.message}")
+      []
+    end
+
     private
 
     # Free margin, not gross cash: capital already committed to open paper

--- a/app/services/alert_processors/base.rb
+++ b/app/services/alert_processors/base.rb
@@ -51,12 +51,16 @@ module AlertProcessors
       end
     end
 
-    # Fetches available balance from DhanHQ::Models::Funds.
-    # Raises an error if the API call fails.
+    # Buying power to size against.
     #
-    # @return [Float] The current available balance in the trading account.
+    # In paper mode this is the simulated book's free capital, not the real
+    # account's. Sizing off the live balance while filling into the paper book
+    # is the worst of both: a funded account sizes trades the simulation never
+    # constrains, and an unfunded one sizes everything to zero.
+    #
+    # @return [Float]
     def available_balance
-      return 100_000 if ENV['PAPER_MODE'] == '1'
+      return paper_available_balance if Paper::Broker.enabled?
 
       @available_balance ||= begin
         funds = DhanHQ::Models::Funds.fetch
@@ -66,8 +70,35 @@ module AlertProcessors
       raise 'Failed to fetch available balance'
     end
 
+    # Today's positions on whichever book this run trades.
+    #
+    # Every guard downstream — entry dedupe, flip, exit, the daily-loss check —
+    # reads this. Pointed at the live book during a paper run it reports an
+    # empty account, so repeated signals stack duplicate paper positions and no
+    # exit ever finds anything to close.
+    #
+    # @return [Array<Hash>]
     def dhan_positions
-      @dhan_positions ||= DhanHQ::Models::Position.all.map(&:attributes)
+      @dhan_positions ||=
+        if Paper::Broker.enabled?
+          Paper::Positions.dhan_shaped
+        else
+          DhanHQ::Models::Position.all.map(&:attributes)
+        end
+    end
+
+    private
+
+    # Free margin, not gross cash: capital already committed to open paper
+    # positions is not available to size the next one.
+    def paper_available_balance
+      @paper_available_balance ||= PaperAccount.current.free_margin.to_f
+    end
+
+    # Which book this run trades, for cache keys that must not be shared
+    # between a simulated and a live session.
+    def book_key
+      Paper::Broker.enabled? ? 'paper' : 'live'
     end
   end
 end

--- a/app/services/alert_processors/index.rb
+++ b/app/services/alert_processors/index.rb
@@ -146,18 +146,18 @@ module AlertProcessors
       end
       log_sizing_success(strike, derivative.lot_size, sizing) if sizing[:lots]
 
-      place_live = Orders::Gateway.place_order_enabled?(logger: Rails.logger, source: self.class.name)
+      # Never pre-check the live gate here. `Orders::Gateway` is what knows
+      # which book an order belongs on, and it routes to `Paper::Exchange`
+      # before consulting PLACE_ORDER/LIVE_TRADING. Deciding "blocked" ahead of
+      # the call meant a paper run never reached the simulator at all: every
+      # index alert was recorded as a dry run and nothing was ever filled.
       if USE_SUPER_ORDER
         order = build_super_order_payload(strike, derivative, quantity)
         return skip!(:ltp_unavailable) unless order
-        return dry_run(order) unless place_live
 
         place_super_order!(order)
       else
-        order = build_legacy_order_payload(derivative, quantity)
-        return dry_run(order) unless place_live
-
-        place_order!(order)
+        place_order!(build_legacy_order_payload(derivative, quantity))
       end
     end
 
@@ -333,7 +333,7 @@ module AlertProcessors
 
     def place_order!(params)
       result = Orders::Gateway.place_order(params, source: self.class.name)
-      return dry_run(params) if result[:dry_run]
+      return unplaced(params, result) unless placed?(result)
 
       order_id = result[:order_id]
       log :info, "order placed  → #{order_id}"
@@ -360,7 +360,7 @@ module AlertProcessors
 
     def place_super_order!(params)
       result = Orders::Gateway.place_super_order(params, source: self.class.name)
-      return dry_run(params) if result[:dry_run]
+      return unplaced(params, result) unless placed?(result)
 
       order_id = result[:order_id]
       log :info, "super-order placed → #{order_id}"
@@ -399,15 +399,35 @@ module AlertProcessors
       row.atr_pct.to_f # eg 0.0082  ( = 0.82 %)
     end
 
-    def dry_run(params)
+    # Whether the order actually reached a book — live or simulated.
+    #
+    # A paper fill answers `dry_run: false`, so it passes; a gate-blocked or
+    # rejected order does not.
+    def placed?(result)
+      !(result[:dry_run] || result[:error] || result[:blocked])
+    end
+
+    # An order that never reached a book. A dry run means a safety gate stopped
+    # it; anything else carries a real reason — in paper mode most often
+    # insufficient simulated margin — and must not be logged as a dry run.
+    def unplaced(params, result)
+      return dry_run(params, result[:message]) if result[:dry_run]
+
+      reason = result[:message].presence || 'order rejected'
+      log :warn, "🚫 order not placed – #{reason}"
+      alert.update!(status: :skipped, error_message: reason, metadata: { rejected_order: params })
+      false
+    end
+
+    def dry_run(params, reason = 'PLACE_ORDER disabled')
       log :info, "dry-run order → #{params}"
       alert.update!(
         status: :skipped,
-        error_message: 'PLACE_ORDER disabled',
+        error_message: reason,
         metadata: { simulated_order: params } # assuming you have a JSONB column
       )
       notify(<<~MSG.strip, tag: 'DRYRUN')
-        💡 DRY-RUN (PLACE_ORDER=false) – Alert ##{alert.id}
+        💡 DRY-RUN (#{reason}) – Alert ##{alert.id}
         • Symbol: #{instrument.symbol_name}
         • Type: #{params[:transaction_type]}
         • Qty: #{params[:quantity]}
@@ -441,11 +461,16 @@ module AlertProcessors
       false
     end
 
-    # Calculate today's realized loss from positions
+    # Today's realised loss on whichever book this run trades.
+    #
+    # Reads `dhan_positions` rather than the SDK directly so a paper run is
+    # guarded by its own losses; against the live book it would always see zero
+    # and the daily cap would never fire. The cache key is scoped to the book
+    # for the same reason.
     def daily_loss_today
-      Rails.cache.fetch("daily_loss:#{Date.current}", expires_in: 1.hour) do
-        positions = DhanHQ::Models::Position.all.map(&:attributes)
-        positions.sum do |pos_hash|
+      Rails.cache.fetch("daily_loss:#{book_key}:#{Date.current}", expires_in: 1.hour) do
+        dhan_positions.sum do |pos|
+          pos_hash = pos.is_a?(Hash) ? pos : pos.to_h
           realized_pnl = pos_hash['realizedProfit'] || pos_hash[:realized_profit] || pos_hash['realized_profit'] || 0
           realized_pnl.to_f.negative? ? realized_pnl.to_f : 0
         end

--- a/app/services/alert_processors/index_position_manager.rb
+++ b/app/services/alert_processors/index_position_manager.rb
@@ -53,7 +53,7 @@ module AlertProcessors
       positions.each do |pos|
         pos_hash = pos.is_a?(Hash) ? pos : pos.to_h
         sec_id = pos_hash['securityId'] || pos_hash[:security_id]
-        qty = pos_hash['quantity'] || pos_hash[:quantity]
+        qty = position_quantity(pos_hash)
 
         payload = {
           transaction_type: 'SELL',
@@ -66,14 +66,28 @@ module AlertProcessors
         }
 
         result = Orders::Gateway.place_order(payload, source: self.class.name)
-        if result[:dry_run]
-          @processor.send(:log, :warn, "blocked #{type.upcase} exit ⇒ security_id=#{sec_id}, quantity=#{qty}")
+        if result[:dry_run] || result[:error] || result[:blocked]
+          @processor.send(:log, :warn,
+                          "blocked #{type.upcase} exit ⇒ security_id=#{sec_id}, quantity=#{qty} " \
+                          "(#{result[:message] || 'no reason given'})")
           next
         end
 
         @processor.send(:log, :info, "#{log_prefix} #{type.upcase} ⇒ security_id=#{sec_id}, quantity=#{qty}")
         @processor.send(:notify, notify_msg, tag: tag)
       end
+    end
+
+    # Dhan's position payload reports `netQty`, not `quantity`, and the paper
+    # book mirrors that shape. Without the fallback an exit went out with a nil
+    # quantity, which the broker rejects and the paper exchange refuses.
+    #
+    # @return [Integer] absolute size to close
+    def position_quantity(pos_hash)
+      explicit = pos_hash['quantity'] || pos_hash[:quantity]
+      return explicit.to_i.abs if explicit.present?
+
+      (pos_hash['netQty'] || pos_hash[:net_qty] || pos_hash['net_qty']).to_i.abs
     end
 
     def open_long_position?(sec_ids)

--- a/app/services/alert_processors/stock.rb
+++ b/app/services/alert_processors/stock.rb
@@ -157,11 +157,15 @@ module AlertProcessors
       false
     end
 
-    # Calculate today's realized loss from positions
+    # Today's realised loss on whichever book this run trades.
+    #
+    # Reads `dhan_positions` rather than the SDK directly so a paper run is
+    # guarded by its own losses; against the live book it would always see zero
+    # and the daily cap would never fire. The cache key is scoped to the book
+    # for the same reason.
     def daily_loss_today
-      Rails.cache.fetch("daily_loss:#{Date.current}", expires_in: 1.hour) do
-        positions = DhanHQ::Models::Position.all
-        positions.sum do |pos|
+      Rails.cache.fetch("daily_loss:#{book_key}:#{Date.current}", expires_in: 1.hour) do
+        dhan_positions.sum do |pos|
           pos_hash = pos.is_a?(Hash) ? pos : pos.to_h
           realized_pnl = pos_hash['realizedProfit'] || pos_hash[:realized_profit] || 0
           realized_pnl.to_f.negative? ? realized_pnl.to_f : 0

--- a/app/services/alert_processors/stock.rb
+++ b/app/services/alert_processors/stock.rb
@@ -270,7 +270,14 @@ module AlertProcessors
     end
 
     # eDIS (idempotent)
+    #
+    # Authorises the depository to debit real shares, so it has no business
+    # running against a simulated sell — it would call the live EDIS API and
+    # block the placement for up to 45 seconds waiting on an approval that
+    # protects nothing here.
     def ensure_edis!(qty)
+      return if Paper::Broker.enabled?
+
       info = Dhanhq::API::EDIS.status(isin: instrument.isin)
       return if info['status'] == 'SUCCESS' && info['aprvdQty'].to_i >= qty
 
@@ -294,11 +301,32 @@ module AlertProcessors
     # ------------------------------------------------------------------------
     #  Helpers delegated to Base / external
     # ------------------------------------------------------------------------
+    # Size currently held in this instrument.
+    #
+    # Delivery strategies have to fall back to holdings: a CNC position is only
+    # in the position book on its trade date, so from T+1 a `long_exit` saw
+    # zero and skipped as `:no_long`, leaving the position open indefinitely.
     def current_qty
       pos = dhan_positions.find { |p| p['securityId'].to_s == instrument.security_id.to_s }
-      pos&.dig('netQty').to_i
+      qty = pos&.dig('netQty').to_i
+      return qty unless qty.zero? && delivery?
+
+      held_qty
     end
     alias fetch_current_net_quantity current_qty
+
+    def delivery?
+      PRODUCT.fetch(alert[:strategy_type]) == 'CNC'
+    end
+
+    # Only the free quantity is sellable — anything still pending delivery (T1)
+    # or pledged as collateral is not.
+    def held_qty
+      holding = dhan_holdings.find { |h| h['securityId'].to_s == instrument.security_id.to_s }
+      return 0 unless holding
+
+      (holding['availableQty'] || holding['totalQty']).to_i
+    end
 
     def leverage_factor
       lev = instrument.mis_detail&.mis_leverage.to_i

--- a/app/services/llm/key_rotator.rb
+++ b/app/services/llm/key_rotator.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+module Llm
+  # Rotates a pool of Ollama Cloud API keys, quarantining any that fail.
+  #
+  # Ollama Cloud authenticates per request with a bearer token, and one key is
+  # a single point of failure: rate limits are counted per key, and a revoked
+  # or exhausted key takes the whole AI layer down with it. Up to five keys are
+  # read from `OLLAMA_API_KEY_1..5` and tried in order.
+  #
+  # Each attempt gets its own `RubyLLM.context` — an isolated copy of the
+  # global configuration — so rotating never mutates process-wide state. That
+  # matters here: the market-feed thread and web requests share this process,
+  # and a global `RubyLLM.configure` from one request would change the key
+  # underneath the other.
+  #
+  # Nothing in this class places orders or reads credentials beyond the LLM
+  # keys; the AI layer proposes, `Strategy::Validator` and `Orders::Gateway`
+  # decide.
+  class KeyRotator
+    MAX_KEYS = 5
+    QUARANTINE = 5.minutes
+    DEFAULT_API_BASE = 'https://ollama.com/v1'
+    DEFAULT_MODEL = 'qwen3-coder:480b-cloud'
+
+    # Failures that mean "this key is no good right now".
+    #
+    # A bad request, an unknown model or a malformed tool call is the caller's
+    # fault: it would fail identically on all five keys, so it is raised
+    # straight through rather than burning the pool.
+    ROTATABLE_ERRORS = [
+      RubyLLM::UnauthorizedError,
+      RubyLLM::ForbiddenError,
+      RubyLLM::PaymentRequiredError,
+      RubyLLM::RateLimitError,
+      RubyLLM::ServerError,
+      RubyLLM::ServiceUnavailableError,
+      RubyLLM::OverloadedError
+    ].freeze
+
+    # Raised when every configured key has been tried and quarantined.
+    class Error < StandardError; end
+
+    class << self
+      # Runs a block against the first healthy key, rotating past any that
+      # fail, and returns whatever the block returns.
+      #
+      # @yieldparam context [RubyLLM::Context] bound to one API key
+      # @yieldparam index [Integer] 1-based key number, for logging
+      # @return [Object] the block's value
+      # @raise [Error] when no key could serve the request
+      def with_key
+        keys = available_keys
+        raise Error, exhausted_message if keys.empty?
+
+        last_error = nil
+        keys.each do |key, index|
+          # `return` rather than falling out of the loop: the block's value is
+          # the whole point of the call, and swallowing it here would hand every
+          # caller a silent nil.
+          return yield(build_context(key), index).tap { revive(index) }
+        rescue *ROTATABLE_ERRORS => e
+          last_error = e
+          quarantine(index, e)
+        end
+
+        raise Error, "all #{keys.size} Ollama key(s) failed; last error: #{last_error.class} - #{last_error.message}"
+      end
+
+      # One-shot prompt with rotation.
+      #
+      # @param prompt [String]
+      # @param system [String, nil] system instructions
+      # @param model [String, nil] defaults to OLLAMA_DEFAULT_MODEL
+      # @return [String] the reply text
+      def ask(prompt, system: nil, model: nil)
+        with_key do |context, _index|
+          chat = build_chat(context, model: model)
+          chat.with_instructions(system) if system.present?
+          chat.ask(prompt).content.to_s
+        end
+      end
+
+      # A chat bound to one key, for callers that need tools or a schema.
+      # The block runs inside the rotation, so a mid-conversation key failure
+      # restarts it on the next key.
+      #
+      # @yieldparam chat [RubyLLM::Chat]
+      # @return [Object] the block's value
+      def with_chat(model: nil)
+        with_key do |context, _index|
+          yield build_chat(context, model: model)
+        end
+      end
+
+      # @return [Boolean] whether any key is configured at all
+      def configured?
+        configured_keys.any?
+      end
+
+      # Per-key state, for diagnostics. Never returns the keys themselves.
+      #
+      # @return [Array<Hash>]
+      def health
+        configured = configured_keys.map(&:last)
+        (1..MAX_KEYS).map do |index|
+          until_at = quarantined_until(index)
+          {
+            key: index,
+            configured: configured.include?(index),
+            quarantined_until: until_at,
+            state: key_state(configured.include?(index), until_at)
+          }
+        end
+      end
+
+      # Clears quarantines. Used by the diagnostics task and by tests.
+      def reset!
+        mutex.synchronize { quarantines.clear }
+      end
+
+      def default_model
+        ENV['OLLAMA_DEFAULT_MODEL'].presence || DEFAULT_MODEL
+      end
+
+      # Ollama Cloud speaks the OpenAI-compatible API, and RubyLLM's Ollama
+      # provider posts to `{api_base}/chat/completions`, so the base has to
+      # carry the `/v1` — without it every request 404s.
+      def api_base
+        ENV['OLLAMA_API_BASE'].presence || DEFAULT_API_BASE
+      end
+
+      private
+
+      def build_chat(context, model: nil)
+        # Cloud model ids are not in RubyLLM's bundled registry, so the model
+        # must be asserted rather than looked up; that in turn requires naming
+        # the provider explicitly.
+        context.chat(model: model || default_model, provider: :ollama, assume_model_exists: true)
+      end
+
+      def build_context(api_key)
+        RubyLLM.context do |config|
+          config.ollama_api_base = api_base
+          config.ollama_api_key = api_key
+        end
+      end
+
+      # Read from the environment on every call rather than memoised: a
+      # long-running process should pick up a rotated key without a restart.
+      #
+      # @return [Array<Array(String, Integer)>] [key, 1-based index] pairs
+      def configured_keys
+        (1..MAX_KEYS).filter_map do |index|
+          key = ENV["OLLAMA_API_KEY_#{index}"].presence
+          [key, index] if key
+        end
+      end
+
+      def available_keys
+        now = Time.current
+        configured_keys.reject do |_key, index|
+          expiry = quarantined_until(index)
+          expiry && expiry > now
+        end
+      end
+
+      def quarantine(index, error)
+        mutex.synchronize { quarantines[index] = Time.current + QUARANTINE }
+        Rails.logger.warn("[Llm::KeyRotator] key ##{index} quarantined for #{QUARANTINE.inspect}: " \
+                          "#{error.class} - #{error.message}")
+      end
+
+      def revive(index)
+        mutex.synchronize { quarantines.delete(index) }
+      end
+
+      def quarantined_until(index)
+        mutex.synchronize { quarantines[index] }
+      end
+
+      def key_state(configured, quarantined_until)
+        return 'not configured' unless configured
+        return 'quarantined' if quarantined_until && quarantined_until > Time.current
+
+        'available'
+      end
+
+      def exhausted_message
+        return 'no Ollama API keys configured (set OLLAMA_API_KEY_1..5)' if configured_keys.empty?
+
+        next_free = mutex.synchronize { quarantines.values.min }
+        "all #{configured_keys.size} Ollama key(s) are quarantined until #{next_free&.iso8601}"
+      end
+
+      def quarantines
+        @quarantines ||= {}
+      end
+
+      def mutex
+        @mutex ||= Mutex.new
+      end
+    end
+  end
+end

--- a/app/services/llm/tools/base.rb
+++ b/app/services/llm/tools/base.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Llm
+  module Tools
+    # Exposes an existing `AI::Tools::*` tool to a plain RubyLLM chat.
+    #
+    # The agent tools already wrap this app's DhanHQ access — option chains,
+    # candles, funds, positions — with the retries, segment mapping and
+    # analyser plumbing that took real work to get right. Re-implementing them
+    # against a `RubyLLM::Tool` base would fork that logic and let the two
+    # drift, which is how an AI layer ends up reasoning over stale data.
+    #
+    # `Agents::Tool` subclasses take a tool context as their first argument and
+    # every tool in this app ignores it, so `nil` is passed through.
+    class Base < RubyLLM::Tool
+      class << self
+        # Declares which agent tool this one delegates to.
+        def delegates_to(agent_tool)
+          @agent_tool = agent_tool
+        end
+
+        attr_reader :agent_tool
+      end
+
+      # RubyLLM derives a tool's name from its full class path, which would
+      # present these to the model as `llm--tools--option_chain`. The model
+      # selects tools by name and repeats it back in every call, so it gets the
+      # short one.
+      def name
+        self.class.name.demodulize.underscore
+      end
+
+      def execute(**args)
+        tool = self.class.agent_tool
+        raise NotImplementedError, "#{self.class} must declare `delegates_to`" unless tool
+
+        tool.new.perform(nil, **args.symbolize_keys)
+      rescue StandardError => e
+        # Returned rather than raised: a tool failure is information the model
+        # can act on ("the chain is unavailable, say so"), whereas an exception
+        # aborts the whole turn.
+        Rails.logger.error("[Llm::Tools] #{self.class.name} failed: #{e.class} - #{e.message}")
+        { error: e.message }
+      end
+    end
+  end
+end

--- a/app/services/llm/tools/candles.rb
+++ b/app/services/llm/tools/candles.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Llm
+  module Tools
+    # Recent OHLC candles with indicators, for market-structure questions.
+    class Candles < Base
+      delegates_to AI::Tools::DhanCandleTool
+
+      description 'Fetch recent OHLC candles and derived indicators for a symbol, for trend and ' \
+                  'market-structure analysis.'
+
+      param :symbol, type: 'string', desc: 'Underlying symbol, e.g. NIFTY or RELIANCE'
+      param :interval, type: 'string', desc: 'Candle interval, e.g. 5m, 15m, 1d'
+      param :limit, type: 'integer', desc: 'How many candles to return (default 20)', required: false
+    end
+  end
+end

--- a/app/services/llm/tools/funds.rb
+++ b/app/services/llm/tools/funds.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Llm
+  module Tools
+    # Trading capital, used margin and the capital band that governs sizing.
+    class Funds < Base
+      delegates_to AI::Tools::FundsTool
+
+      description 'Fetch available trading capital, used margin and the capital-band policy ' \
+                  '(allocation %, risk per trade %, daily max loss %) used for position sizing.'
+    end
+  end
+end

--- a/app/services/llm/tools/market_sentiment.rb
+++ b/app/services/llm/tools/market_sentiment.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Llm
+  module Tools
+    # Aggregate bias from the option chain and price structure.
+    class MarketSentiment < Base
+      delegates_to AI::Tools::MarketSentimentTool
+
+      description 'Fetch the aggregate market bias (bullish / bearish / neutral) for an index, ' \
+                  'derived from option-chain positioning and price structure.'
+
+      param :symbol, type: 'string', desc: 'Index symbol, e.g. NIFTY'
+    end
+  end
+end

--- a/app/services/llm/tools/option_chain.rb
+++ b/app/services/llm/tools/option_chain.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Llm
+  module Tools
+    # Live option chain, IV rank, PCR and ranked strikes for an NSE index.
+    class OptionChain < Base
+      delegates_to AI::Tools::OptionChainTool
+
+      description 'Fetch and analyse the option chain for an NSE index (NIFTY, BANKNIFTY, FINNIFTY). ' \
+                  'Returns spot, IV rank, PCR, sentiment, the best strike and the nearest strikes.'
+
+      param :symbol, type: 'string', desc: 'Index symbol: NIFTY, BANKNIFTY or FINNIFTY'
+      param :expiry, type: 'string', desc: 'Expiry date YYYY-MM-DD; defaults to the nearest', required: false
+      param :signal_type, type: 'string', desc: 'Direction to rank strikes for: ce (bullish) or pe (bearish)',
+                          required: false
+    end
+  end
+end

--- a/app/services/llm/tools/positions.rb
+++ b/app/services/llm/tools/positions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Llm
+  module Tools
+    # Open positions with P&L.
+    class Positions < Base
+      delegates_to AI::Tools::PositionsTool
+
+      description 'Fetch current trading positions with quantity, entry, LTP and P&L.'
+
+      param :filter, type: 'string', desc: "Which positions to return: 'all', 'open' or 'closed'", required: false
+    end
+  end
+end

--- a/app/services/llm/trading_agent.rb
+++ b/app/services/llm/trading_agent.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Llm
+  # Trading-desk analyst backed by Ollama Cloud, with tool access to this
+  # app's live DhanHQ data.
+  #
+  # This is the single-model counterpart to `AI::TradeBrain`, which orchestrates
+  # the multi-agent cluster. Both stop at a *proposal*: execution stays behind
+  # `Strategy::Validator` and `Orders::Gateway`, and no tool exposed here can
+  # place an order.
+  class TradingAgent
+    SYSTEM_PROMPT = <<~PROMPT
+      You are an analyst on an Indian derivatives desk (NSE/BSE). You cover
+      index options, equities, futures and commodities.
+
+      Working rules:
+      - Fetch data with the tools before answering. Never guess a price, a
+        strike, an expiry or a balance.
+      - You propose; you never execute. There is no tool that places an order,
+        and a proposal is reviewed by a deterministic validator before anything
+        reaches a broker.
+      - State the instrument, expiry, strike and side (CE/PE, long/short)
+        explicitly. An ambiguous proposal is useless downstream.
+      - Always give entry, stop-loss and target, and say what the stop is based
+        on (ATR, structure, a fixed percentage).
+      - Size against the capital band from the funds tool. Say the margin
+        required and the worst-case loss.
+      - If the data does not support a trade, say so and stop. "No trade" is a
+        valid answer and a cheaper one than a bad fill.
+      - Times are IST. Be concise: this is read on a phone during market hours.
+    PROMPT
+
+    TOOLS = [
+      Llm::Tools::OptionChain,
+      Llm::Tools::Candles,
+      Llm::Tools::Funds,
+      Llm::Tools::Positions,
+      Llm::Tools::MarketSentiment
+    ].freeze
+
+    class << self
+      # Analysis with full tool access.
+      #
+      # @param prompt [String]
+      # @param model [String, nil]
+      # @return [String]
+      def analyze(prompt, model: nil)
+        KeyRotator.with_chat(model: model) do |chat|
+          chat.with_instructions(SYSTEM_PROMPT)
+            .with_tools(*TOOLS)
+            .ask(prompt)
+            .content.to_s
+        end
+      end
+
+      # A question that needs no live data.
+      #
+      # @return [String]
+      def ask(question, model: nil)
+        KeyRotator.ask(question, system: SYSTEM_PROMPT, model: model)
+      end
+
+      # A trade proposal in the shape `Strategy::Validator` checks.
+      #
+      # The validator is the gate, not the model: this returns the proposal and
+      # the validation result together so a caller never sees an unchecked one.
+      #
+      # @param symbol [String]
+      # @param direction [String, nil] "CE" or "PE"
+      # @return [Hash] :proposal, :validation, :raw
+      def propose(symbol:, direction: nil, model: nil)
+        hint = direction.present? ? " Prefer #{direction.to_s.upcase} if the data supports it." : ''
+        raw = analyze(<<~PROMPT, model: model)
+          Propose one options trade on #{symbol} for the current session.#{hint}
+
+          Answer with a single JSON object and nothing else, using these keys:
+          symbol, direction (CE or PE), strike, entry_price, stop_loss, target,
+          confidence (0-1), product (INTRADAY, MARGIN or CNC), rationale.
+        PROMPT
+
+        proposal = extract_json(raw)
+        {
+          raw: raw,
+          proposal: proposal,
+          validation: proposal ? Strategy::Validator.validate(proposal) : nil
+        }
+      end
+    end
+
+    # Models wrap JSON in prose or a fenced block however they please, so take
+    # the outermost object rather than trusting the whole reply to parse.
+    def self.extract_json(text)
+      candidate = text.to_s[/\{.*\}/m]
+      return nil if candidate.blank?
+
+      JSON.parse(candidate)
+    rescue JSON::ParserError => e
+      Rails.logger.warn("[Llm::TradingAgent] proposal was not valid JSON: #{e.message}")
+      nil
+    end
+  end
+end

--- a/app/services/orders/gateway.rb
+++ b/app/services/orders/gateway.rb
@@ -48,10 +48,15 @@ module Orders
   #
   # With `PAPER_TRADING=true` the domestic paths route to {Paper::Broker},
   # which fills against the live feed with a slippage assumption and persists
-  # the fill as an Order row. Because the switch lives here, every caller gets
-  # paper behaviour without changing code and the result shape is unchanged.
-  # Paper mode intentionally bypasses PLACE_ORDER/LIVE_TRADING: nothing reaches
-  # the broker, so those gates have nothing to protect.
+  # the fill to the `paper_*` tables — never the live `orders` table. Because
+  # the switch lives here, every caller gets paper behaviour without changing
+  # code and the result shape is unchanged. Paper mode intentionally bypasses
+  # PLACE_ORDER/LIVE_TRADING: nothing reaches the broker, so those gates have
+  # nothing to protect.
+  #
+  # That bypass is why callers must not pre-check {.place_order_enabled?} and
+  # skip the call themselves — routing happens here, ahead of the gates, so a
+  # caller that decides "blocked" on its own makes paper mode unreachable.
   class Gateway
     # Asset classes that route to the domestic (INR) order API.
     DOMESTIC_ASSET_CLASSES = %i[equity index options futures currency commodity].freeze
@@ -102,7 +107,9 @@ module Orders
       # @param source [String] caller identifier for logs
       # @return [Hash] result hash with :dry_run or :order details
       def place_super_order(payload, logger: Rails.logger, source: nil)
-        # Paper mode fills the entry leg; the SL/target legs are not simulated.
+        # Paper mode fills the entry leg and then watches the target and stop
+        # on the tick stream (Paper::SuperOrderMonitor); `trailing_jump` is
+        # recorded but not yet trailed.
         return Paper::Broker.place(payload, source: source) if Paper::Broker.enabled?
         return blocked_result(payload, logger: logger, source: source) unless place_order_enabled?(logger: logger, source: source)
 

--- a/app/services/paper/day_rollover.rb
+++ b/app/services/paper/day_rollover.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Paper
+  # Rolls the simulated book onto a new trading day.
+  #
+  # Dhan's position book is day-scoped: yesterday's flat positions are gone,
+  # yesterday's realised P&L is not today's, and a DAY order that never filled
+  # is dead. The paper book is a set of database rows that survive the night, so
+  # without an explicit rollover it drifted further from the broker every day —
+  # stale limits waiting to fill on a week-old intent, and a daily-loss guard
+  # counting losses from previous sessions.
+  #
+  # Lazy and idempotent: `ensure!` runs at most once per day, triggered by the
+  # book's own activity, because this app has no scheduler to hang it off.
+  class DayRollover < ApplicationService
+    ZONE = 'Asia/Kolkata'
+
+    class << self
+      # Rolls the book if it has not been rolled today. Cheap enough to call
+      # before every placement and on every tick — the common case is one date
+      # comparison against an already-loaded account.
+      #
+      # @return [Boolean] whether a rollover ran
+      def ensure!(account: PaperAccount.current, today: Time.current.in_time_zone(ZONE).to_date)
+        return false if account.last_rolled_on == today
+
+        new(account, today).call
+      end
+    end
+
+    def initialize(account = PaperAccount.current, today = Time.current.in_time_zone(ZONE).to_date)
+      @account = account
+      @today = today
+      @margin = MarginCalculator.new(account.settings)
+    end
+
+    # @return [Boolean]
+    def call
+      # A book that has never been rolled is simply starting its first day;
+      # there is nothing from a previous session to clean up.
+      if account.last_rolled_on.nil?
+        account.update!(last_rolled_on: today)
+        return false
+      end
+
+      expired = expire_day_orders
+      dropped = drop_flat_positions
+      reset_daily_realized
+      account.update!(last_rolled_on: today)
+
+      Rails.logger.info("[Paper::DayRollover] rolled onto #{today}: #{expired} order(s) expired, " \
+                        "#{dropped} flat position(s) dropped")
+      true
+    end
+
+    private
+
+    attr_reader :account, :today, :margin
+
+    # DAY validity means exactly that. Anything still resting from a previous
+    # session dies with it, and its margin comes back.
+    def expire_day_orders
+      orders = account.paper_orders.resting.where(validity: 'DAY').to_a
+      orders.each do |order|
+        margin.release_order!(account, order)
+        order.update!(status: 'expired', cancelled_at: Time.current)
+      end
+      orders.size
+    end
+
+    # The broker drops a position that closed out; keeping it would leave the
+    # day-scoped position view reporting flat rows forever.
+    def drop_flat_positions
+      account.paper_positions.where(position_type: PaperPosition::CLOSED).delete_all
+    end
+
+    # Realised P&L on a carry-forward position belongs to the day it was
+    # realised. The account keeps the cumulative figure; the position row
+    # reports the current session, which is what the broker shows and what the
+    # daily-loss guard has to read.
+    def reset_daily_realized
+      account.paper_positions.where.not(realized_profit: 0).update_all(realized_profit: 0) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+end

--- a/app/services/paper/eod_square_off.rb
+++ b/app/services/paper/eod_square_off.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Paper
+  # Closes intraday positions near the close, the way the broker does.
+  #
+  # Dhan squares off open MIS/INTRADAY positions in the last minutes of the
+  # session. Without this the simulated book carried them forever and marked
+  # them against the next day's prices, so a paper "intraday" strategy reported
+  # P&L no intraday trader could have had.
+  #
+  # Only INTRADAY is closed. MARGIN (NRML) and CNC are carry-forward products
+  # at the broker and stay open here for the same reason.
+  #
+  # Idempotent per day: `last_squared_off_on` on the account means the tick
+  # stream can ask on every tick without closing anything twice.
+  class EodSquareOff < ApplicationService
+    ZONE = 'Asia/Kolkata'
+    # Matches Positions::Manager's EOD boundary, which stops managing exits at
+    # the same moment for the live book.
+    CUTOFF_HOUR = 15
+    CUTOFF_MIN = 15
+    INTRADAY_PRODUCTS = %w[INTRADAY].freeze
+
+    class << self
+      # Runs only when the session is past the cutoff and the book has not
+      # already been squared off today. Safe to call on every tick.
+      #
+      # @return [Integer] positions closed
+      def run_if_due(account: PaperAccount.current, now: Time.current.in_time_zone(ZONE))
+        return 0 unless due?(now: now)
+
+        call(account: account, now: now)
+      end
+
+      # @return [Integer] positions closed
+      def call(account: PaperAccount.current, now: Time.current.in_time_zone(ZONE))
+        new(account, now).call
+      end
+
+      # @return [Boolean] whether the session has reached the square-off time
+      def due?(now: Time.current.in_time_zone(ZONE))
+        now.on_weekday? && now >= now.change(hour: CUTOFF_HOUR, min: CUTOFF_MIN)
+      end
+    end
+
+    def initialize(account = PaperAccount.current, now = Time.current.in_time_zone(ZONE))
+      @account = account
+      @now = now
+    end
+
+    def call
+      return 0 if account.last_squared_off_on == now.to_date
+
+      cancel_working_intraday_orders
+      closed = close_intraday_positions
+      account.update!(last_squared_off_on: now.to_date)
+      Rails.logger.info("[Paper::EodSquareOff] squared off #{closed} intraday position(s)") if closed.positive?
+      closed
+    end
+
+    private
+
+    attr_reader :account, :now
+
+    # A working order left alive past the close would fill against tomorrow's
+    # prices on an intent formed today.
+    def cancel_working_intraday_orders
+      account.paper_orders.resting.where(product_type: INTRADAY_PRODUCTS).find_each do |order|
+        Paper::Exchange.cancel(order.id)
+      end
+    end
+
+    def close_intraday_positions
+      positions = account.paper_positions.open_positions.where(product_type: INTRADAY_PRODUCTS).to_a
+
+      positions.count do |position|
+        # Braces matter: `place` takes a positional payload, so bare keywords
+        # would arrive as kwargs and raise. `force` waives the market-hours
+        # check — a square-off run after 15:30 still has to close the book.
+        result = Paper::Exchange.place({
+                                         security_id: position.security_id,
+                                         exchange_segment: position.exchange_segment,
+                                         transaction_type: position.net_qty.positive? ? 'SELL' : 'BUY',
+                                         quantity: position.net_qty.abs,
+                                         order_type: 'MARKET',
+                                         product_type: position.product_type,
+                                         force: true,
+                                         metadata: { 'eod_square_off' => true }
+                                       })
+        !result[:error]
+      end
+    end
+  end
+end

--- a/app/services/paper/exchange.rb
+++ b/app/services/paper/exchange.rb
@@ -50,6 +50,7 @@ module Paper
 
     # @return [Hash] gateway-shaped result
     def place(payload, source: nil)
+      DayRollover.ensure!(account: account)
       params = payload.to_h.symbolize_keys
       errors = validate(params)
       return rejected(params, errors, source: source) if errors.any?
@@ -83,9 +84,14 @@ module Paper
       price = ltp.to_f
       return if price <= 0
 
+      # The tick stream is the only clock this book has, so the session
+      # boundaries hang off it. Both calls are a date comparison in the common
+      # case.
+      DayRollover.ensure!(account: account)
       mark_positions(security_id, price)
       fill_resting_orders(security_id, exchange_segment, price)
       super_monitor.check(security_id, price)
+      EodSquareOff.run_if_due(account: account)
     rescue StandardError => e
       Rails.logger.error("[Paper::Exchange] tick processing failed for #{security_id}: #{e.message}")
     end
@@ -111,7 +117,8 @@ module Paper
                 transaction_type: position.net_qty.positive? ? 'SELL' : 'BUY',
                 quantity: position.net_qty.abs,
                 order_type: 'MARKET',
-                product_type: position.product_type
+                product_type: position.product_type,
+                force: true
               })
       end
       { paper: true, exited: exited.size, results: exited }
@@ -125,11 +132,18 @@ module Paper
 
     def validate(params)
       errors = []
-      errors << 'Market is closed' if enforce_hours? && !market_open?
+      errors << 'Market is closed' if enforce_hours? && !forced?(params) && !market_open?
       errors << 'Quantity must be positive' unless params[:quantity].to_i.positive?
       errors << 'LIMIT orders require a positive price' if limit_without_price?(params)
       errors.concat(lot_size_errors(params))
       errors
+    end
+
+    # A forced order waives the market-hours check. Closing the book — an EOD
+    # square-off, an operator flattening everything — has to work after the
+    # bell, or the position it was meant to close survives into the next day.
+    def forced?(params)
+      params[:force].to_s == 'true'
     end
 
     def limit_without_price?(params)
@@ -378,11 +392,7 @@ module Paper
     end
 
     def release_margin(order)
-      blocked = order.metadata['blocked_margin'].to_f
-      return unless blocked.positive?
-
-      @margin.release!(account, blocked)
-      order.update!(metadata: order.metadata.merge('blocked_margin' => 0))
+      @margin.release_order!(account, order)
     end
 
     # Real market data: WebSocket cache first, REST second.

--- a/app/services/paper/exchange.rb
+++ b/app/services/paper/exchange.rb
@@ -55,6 +55,7 @@ module Paper
       return rejected(params, errors, source: source) if errors.any?
 
       order = build_order(params)
+      FeedSubscriber.follow(segment: order.exchange_segment, security_id: order.security_id)
       margin = @margin.check(account, exchange_segment: order.exchange_segment,
                                       product_type: order.product_type,
                                       quantity: order.quantity,

--- a/app/services/paper/feed_subscriber.rb
+++ b/app/services/paper/feed_subscriber.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Paper
+  # Keeps the market feed watching whatever the simulated book is trading.
+  #
+  # The feed is the matching engine's clock: {Paper::Exchange} fills resting
+  # orders, marks positions and triggers super-order legs from ticks, and
+  # nothing else subscribes what a strategy picks at signal time — an option
+  # strike is not known until the alert arrives. An unsubscribed instrument
+  # rests forever and its position never marks.
+  #
+  # Every method here is additive and none of them start the feed, so a process
+  # running without one is unaffected and keeps falling back to REST pricing.
+  class FeedSubscriber
+    class << self
+      # @param segment [String] e.g. "NSE_FNO"
+      # @param security_id [String, Integer]
+      # @return [Boolean] whether the feed is now watching this instrument
+      def follow(segment:, security_id:)
+        hub = Live::MarketFeedHub.instance
+        return false unless hub.running?
+
+        hub.subscribe(segment: segment, security_id: security_id)
+      rescue StandardError => e
+        Rails.logger.warn("[Paper::FeedSubscriber] could not subscribe #{segment}:#{security_id}: #{e.message}")
+        false
+      end
+
+      # Puts the feed back on everything the book still has working, after a
+      # restart or a fresh `live:feed`. Without it, orders and positions that
+      # survived in the database go unticked: nothing fills, nothing marks.
+      #
+      # @param account [PaperAccount]
+      # @return [Integer] instruments subscribed
+      def restore_book!(account: PaperAccount.current)
+        instruments = account.paper_orders.resting.pluck(:exchange_segment, :security_id) +
+                      account.paper_positions.open_positions.pluck(:exchange_segment, :security_id)
+
+        instruments.uniq.count { |segment, security_id| follow(segment: segment, security_id: security_id) }
+      end
+    end
+  end
+end

--- a/app/services/paper/margin_calculator.rb
+++ b/app/services/paper/margin_calculator.rb
@@ -59,6 +59,20 @@ module Paper
       )
     end
 
+    # Unwinds whatever an order had blocked and clears the marker, so calling
+    # it twice is a no-op. It lives here rather than on the exchange because
+    # the day rollover has to unwind an expiring order's margin too.
+    #
+    # @return [Float] the amount released
+    def release_order!(account, order)
+      blocked = order.metadata['blocked_margin'].to_f
+      return 0.0 unless blocked.positive?
+
+      release!(account, blocked)
+      order.update!(metadata: order.metadata.merge('blocked_margin' => 0))
+      blocked
+    end
+
     # @return [Float] margin a position of this size would consume
     def required_for(exchange_segment:, product_type:, quantity:, price:)
       turnover = quantity.to_i * price.to_f

--- a/app/services/paper/positions.rb
+++ b/app/services/paper/positions.rb
@@ -19,6 +19,27 @@ module Paper
         account.paper_positions.map { |position| serialize(position) }
       end
 
+      # The paper book rendered in the broker's position shape, so guards,
+      # dedupe and exit logic can read it through
+      # {AlertProcessors::Base#dhan_positions} without knowing which book they
+      # are on.
+      #
+      # Both spellings of every key are present. Callers across this app reach
+      # for camelCase (`securityId`, straight off the Dhan API) and snake_case
+      # interchangeably, and a hash answering only one of them would read as a
+      # flat position — which is exactly how a paper run silently places the
+      # same entry twice.
+      #
+      # Closed positions are included, as Dhan includes them: realised P&L
+      # lives on the row that closed, so the daily-loss guard would always see
+      # zero without them.
+      #
+      # @param since [Time] day boundary; Dhan's positions API is day-scoped
+      # @return [Array<ActiveSupport::HashWithIndifferentAccess>]
+      def dhan_shaped(since: Time.current.in_time_zone('Asia/Kolkata').beginning_of_day)
+        account.paper_positions.where(updated_at: since..).map { |position| dhan_attributes(position) }
+      end
+
       # @return [Hash] capital, P&L and charge totals for the book
       def summary
         acct = account
@@ -53,6 +74,31 @@ module Paper
 
       def account
         PaperAccount.current
+      end
+
+      # `realizedProfit` is the row's lifetime realised P&L, not strictly
+      # today's: the paper book has no end-of-day rollover, so a position
+      # reduced at a loss on more than one day over-reports the current day.
+      # Intraday product types close out the same session, so this only bites
+      # a CNC position scaled out across sessions.
+      def dhan_attributes(position)
+        attrs = {
+          security_id: position.security_id,
+          exchange_segment: position.exchange_segment,
+          product_type: position.product_type,
+          trading_symbol: position.trading_symbol,
+          position_type: position.position_type,
+          net_qty: position.net_qty.to_i,
+          buy_qty: position.buy_qty.to_i,
+          sell_qty: position.sell_qty.to_i,
+          buy_avg: position.buy_avg.to_f,
+          sell_avg: position.sell_avg.to_f,
+          realized_profit: position.realized_profit.to_f,
+          unrealized_profit: position.unrealized_profit.to_f,
+          ltp: position.ltp.to_f
+        }
+
+        attrs.merge(attrs.transform_keys { |key| key.to_s.camelize(:lower) }).with_indifferent_access
       end
 
       def serialize(position)

--- a/app/services/paper/positions.rb
+++ b/app/services/paper/positions.rb
@@ -34,10 +34,33 @@ module Paper
       # lives on the row that closed, so the daily-loss guard would always see
       # zero without them.
       #
-      # @param since [Time] day boundary; Dhan's positions API is day-scoped
+      # Day scoping is the rollover's job, not a timestamp filter here. After
+      # {Paper::DayRollover} has run, every surviving row is either still open —
+      # a carry-forward position the broker would also show today — or was
+      # closed during the current session. Rolling from this read path is what
+      # makes that true even on a day the book has not traded yet.
+      #
       # @return [Array<ActiveSupport::HashWithIndifferentAccess>]
-      def dhan_shaped(since: Time.current.in_time_zone('Asia/Kolkata').beginning_of_day)
-        account.paper_positions.where(updated_at: since..).map { |position| dhan_attributes(position) }
+      def dhan_shaped
+        acct = account
+        DayRollover.ensure!(account: acct)
+
+        positions = acct.paper_positions.to_a
+        expiries = derivative_expiries(positions)
+        positions.map { |position| dhan_attributes(position, expiry: expiries[position.security_id]) }
+      end
+
+      # What the book is carrying as delivery, in the broker's holdings shape.
+      #
+      # A CNC buy sits in the position book on the day it trades and moves to
+      # holdings from T+1, so swing and long-term exit logic has to look in
+      # both places or it stops finding the position it is meant to close.
+      #
+      # @return [Array<ActiveSupport::HashWithIndifferentAccess>]
+      def dhan_holdings
+        account.paper_positions.open_positions.where(product_type: 'CNC').map do |position|
+          holding_attributes(position)
+        end
       end
 
       # @return [Hash] capital, P&L and charge totals for the book
@@ -76,12 +99,11 @@ module Paper
         PaperAccount.current
       end
 
-      # `realizedProfit` is the row's lifetime realised P&L, not strictly
-      # today's: the paper book has no end-of-day rollover, so a position
-      # reduced at a loss on more than one day over-reports the current day.
-      # Intraday product types close out the same session, so this only bites
-      # a CNC position scaled out across sessions.
-      def dhan_attributes(position)
+      # `costPrice` and `drvExpiryDate` are here because the exit stack reads
+      # them: Orders::Analyzer prices P&L off `costPrice`, and RiskManager
+      # treats expiry day specially. A paper position missing them analyses as
+      # worthless and gets skipped.
+      def dhan_attributes(position, expiry: nil)
         attrs = {
           security_id: position.security_id,
           exchange_segment: position.exchange_segment,
@@ -93,12 +115,44 @@ module Paper
           sell_qty: position.sell_qty.to_i,
           buy_avg: position.buy_avg.to_f,
           sell_avg: position.sell_avg.to_f,
+          cost_price: position.entry_price,
           realized_profit: position.realized_profit.to_f,
           unrealized_profit: position.unrealized_profit.to_f,
+          drv_expiry_date: expiry,
           ltp: position.ltp.to_f
         }
 
+        with_both_spellings(attrs)
+      end
+
+      def holding_attributes(position)
+        qty = position.net_qty.to_i.abs
+
+        with_both_spellings(
+          security_id: position.security_id,
+          trading_symbol: position.trading_symbol,
+          exchange: position.exchange_segment.to_s.split('_').first,
+          total_qty: qty,
+          available_qty: qty,
+          dp_qty: qty,
+          t1_qty: 0,
+          avg_cost_price: position.entry_price
+        )
+      end
+
+      # Callers reach for camelCase and snake_case interchangeably, so answer
+      # to both rather than betting on which one a given caller learned.
+      def with_both_spellings(attrs)
         attrs.merge(attrs.transform_keys { |key| key.to_s.camelize(:lower) }).with_indifferent_access
+      end
+
+      # One query for the whole set: the exit stack asks per position, and a
+      # lookup each would be a query per row.
+      def derivative_expiries(positions)
+        return {} if positions.empty?
+
+        Derivative.where(security_id: positions.map(&:security_id))
+          .pluck(:security_id, :expiry_date).to_h
       end
 
       def serialize(position)

--- a/app/services/paper/super_order_monitor.rb
+++ b/app/services/paper/super_order_monitor.rb
@@ -26,6 +26,7 @@ module Paper
     # @return [Integer] number of entries closed
     def check(security_id, price)
       entries(security_id).count do |entry|
+        trail!(entry, price)
         leg = breached_leg(entry, price)
         next false unless leg
 
@@ -38,15 +39,56 @@ module Paper
 
     attr_reader :account, :exchange
 
+    # Partly-filled entries are watched too: a super order that filled half its
+    # quantity still has a live position, and leaving it unwatched left it with
+    # no stop at all.
     def entries(security_id)
-      account.paper_orders.super_orders.where(security_id: security_id.to_s, status: 'traded')
+      account.paper_orders.super_orders.where(security_id: security_id.to_s, status: %w[traded part_traded])
+    end
+
+    # Ratchets the stop toward price in whole `trailing_jump` steps, the way a
+    # Dhan super order does: it moves only in the position's favour, and only
+    # once price has travelled a full jump from entry.
+    #
+    # Without this the leg was recorded and then ignored, so every trailing
+    # strategy tested as a fixed stop — flattering anything that gives profit
+    # back and penalising nothing.
+    def trail!(entry, price)
+      params = leg_params(entry)
+      jump = params[:trailing_jump].to_f
+      base = params[:stop_loss_price].to_f
+      entry_price = entry.average_traded_price.to_f
+      return unless jump.positive? && base.positive? && entry_price.positive?
+
+      steps = ((entry.buy? ? price - entry_price : entry_price - price) / jump).floor
+      return if steps < 1
+
+      trailed = entry.buy? ? base + (steps * jump) : base - (steps * jump)
+      return unless improves?(entry, trailed, current_stop(entry, base))
+
+      entry.update!(metadata: entry.metadata.merge('trailed_stop' => trailed))
+      Rails.logger.info("[Paper::SuperOrderMonitor] entry #{entry.id} stop trailed to #{trailed.round(2)}")
+    end
+
+    def improves?(entry, trailed, current)
+      entry.buy? ? trailed > current : trailed < current
+    end
+
+    # The trailed stop once it has moved, otherwise the one placed with the
+    # order.
+    def current_stop(entry, base)
+      entry.metadata['trailed_stop'].presence&.to_f || base
+    end
+
+    def leg_params(entry)
+      (entry.super_order_params || {}).with_indifferent_access
     end
 
     # @return [String, nil] "TARGET", "STOP_LOSS", or nil when neither is hit
     def breached_leg(entry, price)
-      params = (entry.super_order_params || {}).with_indifferent_access
+      params = leg_params(entry)
       target = params[:target_price].to_f
-      stop = params[:stop_loss_price].to_f
+      stop = current_stop(entry, params[:stop_loss_price].to_f)
 
       return 'TARGET' if target.positive? && (entry.buy? ? price >= target : price <= target)
       return 'STOP_LOSS' if stop.positive? && (entry.buy? ? price <= stop : price >= stop)

--- a/app/services/positions/active_cache.rb
+++ b/app/services/positions/active_cache.rb
@@ -11,7 +11,7 @@ module Positions
     #
     # @return [void]
     def self.refresh!
-      positions = DhanHQ::Models::Position.all.map(&:attributes).reject { |p| (p['netQty'] || p[:net_qty]).to_f.zero? }
+      positions = Positions::Source.open
 
       # Build cache key from security_id and segment (enum → string key, string → enum)
       normalized = positions.index_by do |p|

--- a/app/services/positions/manager.rb
+++ b/app/services/positions/manager.rb
@@ -19,9 +19,9 @@ module Positions
 
       cache = Positions::ActiveCache.all
       if cache.blank?
-        Rails.logger.warn('[Positions::Manager] Cache empty — fetching live positions from DhanHQ API')
-        position_list = DhanHQ::Models::Position.all.map(&:attributes)
-        return log_and_skip('No active positions found via DhanHQ API') if position_list.blank?
+        Rails.logger.warn('[Positions::Manager] Cache empty — fetching positions from the active book')
+        position_list = Positions::Source.all
+        return log_and_skip('No active positions found in the active book') if position_list.blank?
 
         position_list.each do |position|
           next unless valid_position?(position)

--- a/app/services/positions/source.rb
+++ b/app/services/positions/source.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Positions
+  # The open-position book for whichever destination this process trades.
+  #
+  # The exit stack — ActiveCache, Positions::Manager, Orders::Manager — was
+  # written against DhanHQ::Models::Position directly, so during a paper run it
+  # inspected an empty live account and no simulated position was ever managed:
+  # no trailing stop, no risk exit, nothing. Reading through here means the same
+  # exit rules run against whichever book the orders actually went to, and the
+  # exits they place route back to Paper::Exchange through Orders::Gateway.
+  class Source
+    class << self
+      # @return [Array<Hash>] positions in the broker's attribute shape
+      def all
+        return Paper::Positions.dhan_shaped if Paper::Broker.enabled?
+
+        DhanHQ::Models::Position.all.map(&:attributes)
+      end
+
+      # @return [Array<Hash>] positions carrying a non-zero net quantity
+      def open
+        all.reject { |position| (position['netQty'] || position[:net_qty]).to_f.zero? }
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,14 @@ require 'action_cable/engine'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# RubyLLM's railtie decides between the new and legacy `acts_as` API on
+# `on_load(:active_record)`, which fires before app initializers — so this flag
+# has to be set here or the choice is already made by the time
+# config/initializers/ruby_llm.rb runs. This app does not use RubyLLM's
+# ActiveRecord persistence at all; opting in avoids the legacy path and its
+# deprecation warning on every boot.
+RubyLLM.config.use_new_acts_as = true
+
 module AlgoTradingApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# RubyLLM global defaults.
+#
+# Only process-wide settings belong here. The Ollama API *key* deliberately
+# does not: keys are rotated per request by `Llm::KeyRotator`, which builds an
+# isolated `RubyLLM.context` for each attempt. Setting one globally would let a
+# quarantined key leak into callers that never asked for it.
+RubyLLM.configure do |config|
+  # Ollama Cloud speaks the OpenAI-compatible API and RubyLLM posts to
+  # `{api_base}/chat/completions`, so the base must include `/v1`.
+  config.ollama_api_base = ENV['OLLAMA_API_BASE'].presence || 'https://ollama.com/v1'
+
+  config.openai_api_key = ENV.fetch('OPENAI_API_KEY', nil)
+  config.openai_api_base = ENV['OPENAI_URI_BASE'].presence
+
+  # Retries inside a single key's attempt. Rotation to the next key happens
+  # above this, in Llm::KeyRotator, once these are exhausted.
+  config.request_timeout = ENV.fetch('LLM_REQUEST_TIMEOUT', 120).to_i
+  config.max_retries = ENV.fetch('LLM_MAX_RETRIES', 2).to_i
+
+  config.logger = Rails.logger
+  config.log_level = Rails.env.production? ? :info : :debug
+  # NOTE: `use_new_acts_as` is set in config/application.rb, not here — the
+  # railtie reads it before app initializers run.
+end

--- a/db/migrate/20260727120000_add_session_dates_to_paper_accounts.rb
+++ b/db/migrate/20260727120000_add_session_dates_to_paper_accounts.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Tracks which trading day the simulated book has already been rolled and
+# squared off for, so both are idempotent no matter how often the tick stream
+# asks.
+class AddSessionDatesToPaperAccounts < ActiveRecord::Migration[8.0]
+  def change
+    change_table :paper_accounts, bulk: true do |t|
+      t.date :last_rolled_on
+      t.date :last_squared_off_on
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_26_141749) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_27_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -319,6 +319,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_26_141749) do
     t.datetime "reset_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "last_rolled_on"
+    t.date "last_squared_off_on"
   end
 
   create_table "paper_orders", force: :cascade do |t|

--- a/lib/openai/chat_router.rb
+++ b/lib/openai/chat_router.rb
@@ -13,8 +13,16 @@ module Openai
                   model:  nil,
                   max_tokens: nil,
                   force: false)
+      return ask_ollama_cloud!(user_prompt, system: system, model: model) if ollama_cloud?
+
+      ask_openai!(user_prompt, system: system, model: model, max_tokens: max_tokens, force: force)
+    end
+
+    def self.ask_openai!(user_prompt, system:, model: nil, max_tokens: nil, force: false)
       mdl = resolve_model(model, force, "#{system} #{user_prompt}")
-      Rails.logger.info "[Openai] #{backend_label(mdl)}"
+      # Not `backend_label`: on the fallback path that would claim Ollama Cloud
+      # while OpenAI is actually serving the request.
+      Rails.logger.info "[Openai] #{openai_backend_label(mdl)}"
       params = {
         model: mdl,
         messages: [
@@ -29,8 +37,35 @@ module Openai
       resp.dig('choices', 0, 'message', 'content').to_s.strip
     end
 
+    # Ollama Cloud, through the rotating key pool.
+    #
+    # Every existing caller — the screener, the portfolio and position
+    # analysers, the market commentary — reaches this class rather than a
+    # client, so switching backend is an env change rather than a code change.
+    # If the keys are missing the flag is ignored and OpenAI still serves the
+    # request, so a half-finished rollout cannot take the AI layer down.
+    def self.ask_ollama_cloud!(user_prompt, system:, model: nil)
+      Rails.logger.info "[Openai] #{backend_label(model)}"
+      TelegramNotifier.send_chat_action(chat_id: nil, action: 'typing')
+      Llm::KeyRotator.ask(user_prompt, system: system, model: model).strip
+    rescue Llm::KeyRotator::Error => e
+      Rails.logger.error("[Openai] Ollama Cloud unavailable, falling back to OpenAI: #{e.message}")
+      ask_openai!(user_prompt, system: system, model: model)
+    end
+
+    # @return [Boolean] whether Ollama Cloud should serve chat requests
+    def self.ollama_cloud?
+      ENV['LLM_BACKEND'].to_s.casecmp('ollama_cloud').zero? && Llm::KeyRotator.configured?
+    end
+
     # Public: so callers can show which backend will be used (e.g. in Telegram).
     def self.backend_label(resolved_model = nil)
+      return "Ollama Cloud (#{resolved_model || Llm::KeyRotator.default_model})" if ollama_cloud?
+
+      openai_backend_label(resolved_model)
+    end
+
+    def self.openai_backend_label(resolved_model = nil)
       if using_ollama?
         "Ollama (#{resolved_model || ollama_model_from_env})"
       else

--- a/lib/tasks/live_feed.rake
+++ b/lib/tasks/live_feed.rake
@@ -11,6 +11,7 @@ namespace :live do
 
     subscribe_from_env(hub)
     subscribe_watchlist(hub) if ENV['SUBSCRIBE_WATCHLIST'] == 'true'
+    subscribe_paper_book if Paper::Broker.enabled?
 
     puts "⚡ market feed running (mode=#{mode}, subscriptions=#{hub.subscriptions.size})"
     puts '   Ctrl-C to stop.'
@@ -79,6 +80,15 @@ namespace :live do
 
       hub.subscribe(segment: segment, security_id: security_id)
     end
+  end
+
+  # Anything the paper book still has working needs ticks from the moment the
+  # feed comes up, not from the next order.
+  def subscribe_paper_book
+    count = Paper::FeedSubscriber.restore_book!
+    puts "📄 paper book restored: #{count} instrument(s) subscribed"
+  rescue StandardError => e
+    Rails.logger.warn("[live:feed] could not restore paper-book subscriptions: #{e.message}")
   end
 
   def subscribe_watchlist(hub)

--- a/lib/tasks/live_feed.rake
+++ b/lib/tasks/live_feed.rake
@@ -66,6 +66,22 @@ namespace :live do
     pp Paper::Positions.summary
   end
 
+  desc 'Square off the paper book\'s intraday positions now (as the broker would at 15:15 IST)'
+  task paper_eod: :environment do
+    closed = Paper::EodSquareOff.call
+    puts "🔔 squared off #{closed} intraday paper position(s)"
+    pp Paper::Positions.summary
+  end
+
+  desc 'Roll the paper book onto the current trading day (expire DAY orders, drop flat positions)'
+  task paper_roll: :environment do
+    if Paper::DayRollover.ensure!
+      puts '📆 paper book rolled onto the current session'
+    else
+      puts '📆 paper book was already on the current session'
+    end
+  end
+
   desc 'Reset the simulated paper book to its starting capital'
   task paper_reset: :environment do
     account = Paper::Positions.reset!

--- a/lib/tasks/llm.rake
+++ b/lib/tasks/llm.rake
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+namespace :llm do
+  desc 'Show which Ollama Cloud keys are configured and whether any are quarantined'
+  task keys: :environment do
+    Llm::KeyRotator.health.each do |row|
+      icon = { 'available' => '✅', 'quarantined' => '⏳', 'not configured' => '➖' }[row[:state]]
+      suffix = row[:quarantined_until] ? " until #{row[:quarantined_until].iso8601}" : ''
+      puts format('  key #%<key>d  %<icon>s %<state>s%<suffix>s',
+                  key: row[:key], icon: icon, state: row[:state], suffix: suffix)
+    end
+    puts "\nbase=#{Llm::KeyRotator.api_base}  model=#{Llm::KeyRotator.default_model}"
+  end
+
+  desc 'Send a one-token probe through every configured key to see which actually work'
+  task check_keys: :environment do
+    abort('❌ no keys configured; set OLLAMA_API_KEY_1..5') unless Llm::KeyRotator.configured?
+
+    Llm::KeyRotator.reset!
+    (1..Llm::KeyRotator::MAX_KEYS).each do |index|
+      key = ENV["OLLAMA_API_KEY_#{index}"].presence
+      next puts("  key ##{index}: ➖ not configured") unless key
+
+      context = RubyLLM.context do |config|
+        config.ollama_api_base = Llm::KeyRotator.api_base
+        config.ollama_api_key = key
+      end
+      chat = context.chat(model: Llm::KeyRotator.default_model, provider: :ollama, assume_model_exists: true)
+      reply = chat.ask('Reply with the single word: OK').content.to_s.strip
+
+      puts "  key ##{index}: ✅ healthy (#{reply.truncate(40)})"
+    rescue StandardError => e
+      puts "  key ##{index}: ❌ #{e.class} - #{e.message}"
+    end
+  end
+
+  desc 'Ask the trading agent a question. PROMPT="..." [MODEL=...]'
+  task ask: :environment do
+    prompt = ENV['PROMPT'].presence || abort('❌ set PROMPT="your question"')
+    puts Llm::TradingAgent.analyze(prompt, model: ENV.fetch('MODEL', nil))
+  end
+
+  desc 'Generate and validate a trade proposal. SYMBOL=NIFTY [DIRECTION=CE]'
+  task propose: :environment do
+    result = Llm::TradingAgent.propose(symbol: ENV.fetch('SYMBOL', 'NIFTY'), direction: ENV.fetch('DIRECTION', nil))
+
+    puts result[:raw]
+    puts "\n--- parsed ---"
+    pp result[:proposal]
+    puts "\n--- validation (Strategy::Validator decides, not the model) ---"
+    pp result[:validation]
+  end
+end

--- a/spec/lib/openai/chat_router_backend_spec.rb
+++ b/spec/lib/openai/chat_router_backend_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Six services reach the LLM through this class — the screener, the portfolio
+# and position analysers, the market commentary. Switching them to Ollama Cloud
+# has to be an env change, not six code changes.
+RSpec.describe Openai::ChatRouter do
+  before { allow(TelegramNotifier).to receive(:send_chat_action) }
+
+  def with_env(vars)
+    stub_const('ENV', ENV.to_h.merge(vars).compact)
+  end
+
+  describe '.ask!' do
+    it 'routes to Ollama Cloud when the backend is selected and keys exist' do
+      with_env('LLM_BACKEND' => 'ollama_cloud', 'OLLAMA_API_KEY_1' => 'key-one')
+      allow(Llm::KeyRotator).to receive(:ask).and_return('  from ollama  ')
+
+      expect(described_class.ask!('what is the pcr', system: 'be brief')).to eq('from ollama')
+      expect(Llm::KeyRotator).to have_received(:ask).with('what is the pcr', system: 'be brief', model: nil)
+    end
+
+    # A half-finished rollout — the flag set before the keys are in place —
+    # must not take the AI layer down.
+    it 'stays on OpenAI when the flag is set but no key is configured' do
+      with_env({ 'LLM_BACKEND' => 'ollama_cloud' }.merge((1..5).to_h { |i| ["OLLAMA_API_KEY_#{i}", nil] }))
+      allow(Llm::KeyRotator).to receive(:ask)
+      allow(described_class).to receive(:ask_openai!).and_return('from openai')
+
+      expect(described_class.ask!('hello')).to eq('from openai')
+      expect(Llm::KeyRotator).not_to have_received(:ask)
+    end
+
+    it 'ignores the key pool when the backend is not selected' do
+      with_env('LLM_BACKEND' => nil, 'OLLAMA_API_KEY_1' => 'key-one')
+      allow(Llm::KeyRotator).to receive(:ask)
+      allow(described_class).to receive(:ask_openai!).and_return('from openai')
+
+      expect(described_class.ask!('hello')).to eq('from openai')
+      expect(Llm::KeyRotator).not_to have_received(:ask)
+    end
+
+    # Losing every key should degrade to the other provider, not to an
+    # exception in the middle of a screener run.
+    it 'falls back to OpenAI when every Ollama key is exhausted' do
+      with_env('LLM_BACKEND' => 'ollama_cloud', 'OLLAMA_API_KEY_1' => 'key-one')
+      allow(Llm::KeyRotator).to receive(:ask).and_raise(Llm::KeyRotator::Error, 'all keys quarantined')
+      allow(described_class).to receive(:ask_openai!).and_return('from openai')
+
+      expect(described_class.ask!('hello')).to eq('from openai')
+    end
+  end
+
+  describe '.backend_label' do
+    it 'names Ollama Cloud when it is serving' do
+      with_env('LLM_BACKEND' => 'ollama_cloud', 'OLLAMA_API_KEY_1' => 'key-one',
+               'OLLAMA_DEFAULT_MODEL' => 'qwen3:cloud')
+
+      expect(described_class.backend_label).to eq('Ollama Cloud (qwen3:cloud)')
+    end
+
+    it 'names OpenAI otherwise' do
+      with_env({ 'LLM_BACKEND' => nil, 'OPENAI_URI_BASE' => 'https://api.openai.com/v1' })
+
+      expect(described_class.backend_label).to include('OpenAI')
+    end
+  end
+end

--- a/spec/services/alert_processors/base_paper_book_spec.rb
+++ b/spec/services/alert_processors/base_paper_book_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The read side of a paper run has to come from the paper book. Sizing off the
+# live balance while filling into the simulator is the worst of both worlds,
+# and guards pointed at an empty live book let duplicate entries through and
+# never find a position to exit.
+RSpec.describe AlertProcessors::Base, type: :service do
+  subject(:processor) { described_class.new(alert) }
+
+  let(:instrument) { create(:instrument, segment: 'equity', exchange: 'NSE', security_id: '1333') }
+  let(:alert) { create(:alert, instrument_type: 'stock', instrument: instrument) }
+
+  let!(:paper_account) do
+    PaperAccount.create!(initial_capital: 1_000_000, available_balance: 400_000,
+                         blocked_margin: 150_000, config: PaperAccount::DEFAULT_CONFIG.dup)
+  end
+
+  around do |example|
+    original = ENV.fetch('PAPER_TRADING', nil)
+    ENV['PAPER_TRADING'] = paper_enabled
+    example.run
+    ENV['PAPER_TRADING'] = original
+  end
+
+  context 'when paper trading is enabled' do
+    let(:paper_enabled) { 'true' }
+
+    describe '#available_balance' do
+      it 'sizes against the simulated book, not the real account' do
+        allow(DhanHQ::Models::Funds).to receive(:fetch)
+
+        expect(processor.available_balance).to eq(250_000.0)
+        expect(DhanHQ::Models::Funds).not_to have_received(:fetch)
+      end
+    end
+
+    describe '#dhan_positions' do
+      it 'reads the paper book' do
+        paper_account.paper_positions.create!(
+          security_id: '1333', exchange_segment: 'NSE_EQ', product_type: 'INTRADAY',
+          position_type: 'LONG', net_qty: 10, buy_qty: 10, buy_avg: 1_500.0
+        )
+        allow(DhanHQ::Models::Position).to receive(:all)
+
+        expect(processor.dhan_positions.pluck('securityId')).to eq(['1333'])
+        expect(DhanHQ::Models::Position).not_to have_received(:all)
+      end
+    end
+  end
+
+  context 'when paper trading is disabled' do
+    let(:paper_enabled) { 'false' }
+
+    it 'reads funds from the broker' do
+      # Not an instance_double: the SDK resolves attributes dynamically, so
+      # `available_balance` is not a statically defined instance method.
+      funds = double('Funds', available_balance: 75_000.0)
+      allow(DhanHQ::Models::Funds).to receive(:fetch).and_return(funds)
+
+      expect(processor.available_balance).to eq(75_000.0)
+    end
+
+    it 'reads positions from the broker' do
+      allow(DhanHQ::Models::Position).to receive(:all).and_return([])
+
+      expect(processor.dhan_positions).to eq([])
+      expect(DhanHQ::Models::Position).to have_received(:all)
+    end
+  end
+end

--- a/spec/services/alert_processors/delivery_exit_spec.rb
+++ b/spec/services/alert_processors/delivery_exit_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'stringio'
+
+# A CNC position is in the *position* book only on its trade date; from T+1 the
+# broker reports it as a holding. Exit logic that only ever looked at positions
+# saw zero and skipped, so a swing or long-term position was never closed on any
+# day but the first.
+RSpec.describe AlertProcessors::Stock, type: :service do
+  let(:instrument) { create(:instrument, security_id: '1333') }
+  let(:flat_position) { [{ 'securityId' => '1333', 'netQty' => 0 }] }
+  let(:holding) { [{ 'securityId' => '1333', 'totalQty' => 40, 'availableQty' => 40 }] }
+
+  def processor_for(strategy_type:, signal_type:, positions:, holdings:)
+    alert = create(:alert, :pending_status, :delayed,
+                   instrument: instrument, strategy_type: strategy_type, signal_type: signal_type)
+    described_class.new(alert).tap do |proc|
+      allow(proc).to receive_messages(
+        ltp: 100.0, available_balance: 100_000.0,
+        dhan_positions: positions, dhan_holdings: holdings,
+        logger: Logger.new(StringIO.new, level: :fatal)
+      )
+    end
+  end
+
+  it 'finds a swing position that has moved to holdings' do
+    proc = processor_for(strategy_type: 'swing', signal_type: 'long_exit',
+                         positions: flat_position, holdings: holding)
+
+    expect(proc.current_qty).to eq(40)
+  end
+
+  it 'lets the exit through instead of skipping as :no_long' do
+    proc = processor_for(strategy_type: 'swing', signal_type: 'long_exit',
+                         positions: flat_position, holdings: holding)
+
+    expect(proc.signal_guard?).to be(true)
+  end
+
+  it 'sells only the free quantity, never the part pending delivery' do
+    proc = processor_for(strategy_type: 'long_term', signal_type: 'long_exit',
+                         positions: flat_position,
+                         holdings: [{ 'securityId' => '1333', 'totalQty' => 40, 'availableQty' => 25 }])
+
+    expect(proc.current_qty).to eq(25)
+  end
+
+  # Intraday is squared off daily and never becomes a holding, so a holdings
+  # fallback there would be reading someone else's position.
+  it 'does not consult holdings for an intraday signal' do
+    proc = processor_for(strategy_type: 'intraday', signal_type: 'long_exit',
+                         positions: flat_position, holdings: holding)
+
+    expect(proc.current_qty).to eq(0)
+  end
+
+  it 'prefers the position book while the position is still in it' do
+    proc = processor_for(strategy_type: 'swing', signal_type: 'long_exit',
+                         positions: [{ 'securityId' => '1333', 'netQty' => 15 }], holdings: holding)
+
+    expect(proc.current_qty).to eq(15)
+  end
+
+  # eDIS authorises a depository debit of real shares. Running it for a
+  # simulated sell calls the live API and blocks the placement for up to 45s.
+  describe 'eDIS' do
+    around do |example|
+      original = ENV.fetch('PAPER_TRADING', nil)
+      ENV['PAPER_TRADING'] = 'true'
+      example.run
+      ENV['PAPER_TRADING'] = original
+    end
+
+    it 'is skipped in paper mode' do
+      allow(Dhanhq::API::EDIS).to receive(:status)
+      proc = processor_for(strategy_type: 'swing', signal_type: 'long_exit',
+                           positions: flat_position, holdings: holding)
+
+      proc.send(:ensure_edis!, 40)
+
+      expect(Dhanhq::API::EDIS).not_to have_received(:status)
+    end
+  end
+end

--- a/spec/services/alert_processors/index_spec.rb
+++ b/spec/services/alert_processors/index_spec.rb
@@ -152,20 +152,75 @@ RSpec.describe AlertProcessors::Index, type: :service do
 
     context 'when dry-run mode is active' do
       before do
-        allow(processor).to receive(:place_order!) { raise 'should not place' }
-        allow(processor).to receive(:place_super_order!) { raise 'should not place' }
-        allow(processor).to receive(:dry_run).and_call_original
         @orig_place_order = ENV.fetch('PLACE_ORDER', nil)
         ENV['PLACE_ORDER'] = 'false'
       end
 
       after { ENV['PLACE_ORDER'] = @orig_place_order }
 
-      it 'performs dry-run instead of placing real order', vcr: { cassette_name: 'dhan/option_expiry_list' } do
+      # The gate is the gateway's to enforce, not the processor's. The
+      # processor must hand the order over regardless and route the blocked
+      # result to #dry_run — checking the gate here instead is what stopped
+      # paper mode from ever reaching Paper::Exchange.
+      it 'still calls the gateway and records its refusal',
+         vcr: { cassette_name: 'dhan/option_expiry_list' } do
+        allow(Orders::Gateway).to receive(:place_super_order).and_call_original
+
         processor.call
 
+        expect(Orders::Gateway).to have_received(:place_super_order)
         expect(alert.reload.status).to eq('skipped')
-        expect(alert.error_message).to eq('PLACE_ORDER disabled')
+        expect(alert.error_message).to eq('PLACE_ORDER is not true; order not sent.')
+      end
+
+      it 'does not reach the broker', vcr: { cassette_name: 'dhan/option_expiry_list' } do
+        allow(DhanHQ::Models::SuperOrder).to receive(:create)
+
+        processor.call
+
+        expect(DhanHQ::Models::SuperOrder).not_to have_received(:create)
+      end
+    end
+
+    # The whole point of paper mode: the order must reach the simulator even
+    # though the live gates are off. Pre-checking PLACE_ORDER here used to mark
+    # every index alert as a dry run, so nothing was ever simulated.
+    context 'when paper trading is enabled' do
+      let!(:paper_account) do
+        PaperAccount.create!(
+          initial_capital: 1_000_000, available_balance: 1_000_000,
+          config: PaperAccount::DEFAULT_CONFIG.merge('market_hours_enforced' => false)
+        )
+      end
+
+      before do
+        @orig_paper = ENV.fetch('PAPER_TRADING', nil)
+        @orig_place_order = ENV.fetch('PLACE_ORDER', nil)
+        ENV['PAPER_TRADING'] = 'true'
+        ENV['PLACE_ORDER'] = 'false'
+      end
+
+      after do
+        ENV['PAPER_TRADING'] = @orig_paper
+        ENV['PLACE_ORDER'] = @orig_place_order
+      end
+
+      it 'fills into the paper book instead of dry-running',
+         vcr: { cassette_name: 'dhan/option_expiry_list' } do
+        expect { processor.call }.to change { paper_account.paper_orders.count }.by(1)
+
+        expect(alert.reload.status).to eq('processed')
+        expect(paper_account.paper_orders.last).to have_attributes(
+          security_id: derivative.security_id, quantity: 150, status: 'traded'
+        )
+      end
+
+      it 'never reaches the broker', vcr: { cassette_name: 'dhan/option_expiry_list' } do
+        allow(DhanHQ::Models::SuperOrder).to receive(:create)
+
+        processor.call
+
+        expect(DhanHQ::Models::SuperOrder).not_to have_received(:create)
       end
     end
 

--- a/spec/services/llm/key_rotator_spec.rb
+++ b/spec/services/llm/key_rotator_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Llm::KeyRotator do
+  let(:keys) { { 1 => 'key-one', 2 => 'key-two', 3 => 'key-three' } }
+
+  before do
+    described_class.reset!
+    (1..described_class::MAX_KEYS).each do |index|
+      stub_const('ENV', ENV.to_h.merge("OLLAMA_API_KEY_#{index}" => keys[index]).compact)
+    end
+  end
+
+  after { described_class.reset! }
+
+  describe '.with_key' do
+    it 'uses the first configured key' do
+      used = described_class.with_key { |_context, index| index }
+
+      expect(used).to eq(1)
+    end
+
+    # The draft this replaces returned nil on success: a bare `return` after
+    # the yield discarded the model's reply, so every caller got nothing.
+    it 'returns the block value rather than swallowing it' do
+      expect(described_class.with_key { |_c, _i| 'the answer' }).to eq('the answer')
+    end
+
+    it 'rotates to the next key when one is unauthorized' do
+      attempts = []
+
+      result = described_class.with_key do |_context, index|
+        attempts << index
+        raise RubyLLM::UnauthorizedError, 'revoked' if index == 1
+
+        'served by two'
+      end
+
+      expect(attempts).to eq([1, 2])
+      expect(result).to eq('served by two')
+    end
+
+    it 'rotates past a rate-limited key' do
+      attempts = []
+
+      described_class.with_key do |_context, index|
+        attempts << index
+        raise RubyLLM::RateLimitError, 'slow down' if index < 3
+
+        'ok'
+      end
+
+      expect(attempts).to eq([1, 2, 3])
+    end
+
+    it 'keeps a failed key out of rotation while it is quarantined' do
+      described_class.with_key do |_context, index|
+        raise RubyLLM::ServerError, 'boom' if index == 1
+
+        'ok'
+      end
+
+      expect(described_class.with_key { |_c, index| index }).to eq(2)
+    end
+
+    it 'lets the key back in once the quarantine lapses' do
+      described_class.with_key do |_context, index|
+        raise RubyLLM::ServerError, 'boom' if index == 1
+
+        'ok'
+      end
+
+      travel_to(described_class::QUARANTINE.from_now + 1.second) do
+        expect(described_class.with_key { |_c, index| index }).to eq(1)
+      end
+    end
+
+    it 'raises once every key has failed' do
+      expect do
+        described_class.with_key { |_c, _i| raise RubyLLM::UnauthorizedError, 'nope' }
+      end.to raise_error(described_class::Error, /last error/)
+    end
+
+    # A malformed request fails identically on all five keys. Rotating would
+    # burn the whole pool over a caller-side bug.
+    it 'does not rotate on an error that is the caller\'s fault' do
+      attempts = []
+
+      expect do
+        described_class.with_key do |_context, index|
+          attempts << index
+          raise RubyLLM::BadRequestError, 'malformed tool call'
+        end
+      end.to raise_error(RubyLLM::BadRequestError)
+
+      expect(attempts).to eq([1])
+      expect(described_class.health.first[:state]).to eq('available')
+    end
+
+    it 'explains itself when no key is configured' do
+      stub_const('ENV', ENV.to_h.except(*(1..5).map { |i| "OLLAMA_API_KEY_#{i}" }))
+
+      expect { described_class.with_key { |_c, _i| 'unused' } }
+        .to raise_error(described_class::Error, /no Ollama API keys configured/)
+    end
+  end
+
+  describe '.with_key context isolation' do
+    # The market-feed thread and web requests share this process; a global
+    # RubyLLM.configure would swap the key underneath a concurrent caller.
+    it 'binds the key to a context without touching global config' do
+      before_key = RubyLLM.config.ollama_api_key
+
+      described_class.with_key do |context, _index|
+        expect(context.config.ollama_api_key).to eq('key-one')
+        expect(context.config.ollama_api_base).to eq(described_class.api_base)
+      end
+
+      expect(RubyLLM.config.ollama_api_key).to eq(before_key)
+    end
+  end
+
+  describe '.health' do
+    it 'reports every slot without ever exposing a key' do
+      health = described_class.health
+
+      expect(health.size).to eq(described_class::MAX_KEYS)
+      expect(health.pluck(:state))
+        .to eq(['available', 'available', 'available', 'not configured', 'not configured'])
+      expect(health.to_s).not_to include('key-one')
+    end
+  end
+
+  describe '.configured?' do
+    it 'is false with no keys' do
+      stub_const('ENV', ENV.to_h.except(*(1..5).map { |i| "OLLAMA_API_KEY_#{i}" }))
+
+      expect(described_class).not_to be_configured
+    end
+
+    it 'is true with at least one' do
+      expect(described_class).to be_configured
+    end
+  end
+
+  describe '.api_base' do
+    # RubyLLM posts to {base}/chat/completions, so a base without /v1 makes
+    # every request 404 against Ollama Cloud.
+    it 'defaults to the OpenAI-compatible path' do
+      stub_const('ENV', ENV.to_h.except('OLLAMA_API_BASE'))
+
+      expect(described_class.api_base).to end_with('/v1')
+    end
+  end
+end

--- a/spec/services/llm/tools_spec.rb
+++ b/spec/services/llm/tools_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The Llm tools are wrappers, not reimplementations: the agent tools already
+# hold this app's DhanHQ plumbing, and a second copy would drift from it.
+RSpec.describe Llm::Tools::Base do
+  describe 'delegation' do
+    it 'passes arguments through to the agent tool' do
+      agent_tool = instance_double(AI::Tools::OptionChainTool, perform: { symbol: 'NIFTY' })
+      allow(AI::Tools::OptionChainTool).to receive(:new).and_return(agent_tool)
+
+      result = Llm::Tools::OptionChain.new.execute(symbol: 'NIFTY', signal_type: 'ce')
+
+      expect(result).to eq({ symbol: 'NIFTY' })
+      expect(agent_tool).to have_received(:perform).with(nil, symbol: 'NIFTY', signal_type: 'ce')
+    end
+
+    it 'accepts the string keys a model sends' do
+      agent_tool = instance_double(AI::Tools::PositionsTool, perform: [])
+      allow(AI::Tools::PositionsTool).to receive(:new).and_return(agent_tool)
+
+      Llm::Tools::Positions.new.execute('filter' => 'open')
+
+      expect(agent_tool).to have_received(:perform).with(nil, filter: 'open')
+    end
+
+    # A raised exception aborts the whole turn; a returned error is something
+    # the model can report or work around.
+    it 'returns a tool failure rather than raising' do
+      allow(AI::Tools::FundsTool).to receive(:new).and_raise(StandardError, 'broker down')
+
+      expect(Llm::Tools::Funds.new.execute).to eq({ error: 'broker down' })
+    end
+  end
+
+  describe 'declarations' do
+    it 'gives every tool a description the model can choose on' do
+      Llm::TradingAgent::TOOLS.each do |tool|
+        expect(tool.description).to be_present, "#{tool} has no description"
+      end
+    end
+
+    it 'names tools without the class path' do
+      expect(Llm::Tools::OptionChain.new.name).to eq('option_chain')
+    end
+
+    it 'wires each tool to an agent tool' do
+      Llm::TradingAgent::TOOLS.each do |tool|
+        expect(tool.agent_tool).to be < AI::Tools::Base if defined?(AI::Tools::Base)
+        expect(tool.agent_tool).to be_present, "#{tool} declares no delegates_to"
+      end
+    end
+  end
+end

--- a/spec/services/paper/day_session_spec.rb
+++ b/spec/services/paper/day_session_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The two session boundaries the simulated book needs to behave like a broker's:
+# squaring off intraday at the close, and rolling onto a new trading day.
+RSpec.describe 'Paper day session' do
+  let(:account) do
+    PaperAccount.create!(
+      initial_capital: 1_000_000, available_balance: 1_000_000,
+      config: PaperAccount::DEFAULT_CONFIG.merge('market_hours_enforced' => false, 'slippage_bps' => 0)
+    )
+  end
+
+  before do
+    Live::TickCache.clear!
+    Live::TickCache.put('NSE_EQ', '1333', ltp: 1_500.0)
+  end
+
+  after { Live::TickCache.clear! }
+
+  def open_position(product_type: 'INTRADAY', **attrs)
+    account.paper_positions.create!(
+      { security_id: '1333', exchange_segment: 'NSE_EQ', product_type: product_type,
+        position_type: 'LONG', net_qty: 10, buy_qty: 10, buy_avg: 1_400.0 }.merge(attrs)
+    )
+  end
+
+  def resting_order(**attrs)
+    account.paper_orders.create!(
+      { security_id: '1333', exchange_segment: 'NSE_EQ', transaction_type: 'BUY', order_type: 'LIMIT',
+        product_type: 'INTRADAY', validity: 'DAY', quantity: 10, price: 1_000.0, status: 'pending' }.merge(attrs)
+    )
+  end
+
+  describe Paper::EodSquareOff do
+    it 'closes an intraday position at the close' do
+      open_position
+
+      expect(described_class.call(account: account)).to eq(1)
+      expect(account.paper_positions.open_positions).to be_empty
+    end
+
+    # MARGIN (NRML) and CNC are carry-forward products at the broker; squaring
+    # them off would invent an exit no real book would have taken.
+    it 'leaves carry-forward products alone' do
+      open_position(product_type: 'MARGIN', security_id: '49081', exchange_segment: 'NSE_FNO')
+      open_position(product_type: 'CNC', security_id: '2885')
+
+      expect(described_class.call(account: account)).to eq(0)
+      expect(account.paper_positions.open_positions.count).to eq(2)
+    end
+
+    it 'cancels working intraday orders so none survive the session' do
+      order = resting_order
+
+      described_class.call(account: account)
+
+      expect(order.reload.status).to eq('cancelled')
+    end
+
+    it 'runs once a day however often it is asked' do
+      open_position
+
+      expect(described_class.call(account: account)).to eq(1)
+      expect(described_class.call(account: account.reload)).to eq(0)
+    end
+
+    describe '.due?' do
+      it 'is due at the cut-off on a weekday' do
+        expect(described_class.due?(now: Time.zone.parse('2026-07-27 15:16'))).to be(true)
+      end
+
+      it 'is not due mid-session' do
+        expect(described_class.due?(now: Time.zone.parse('2026-07-27 11:00'))).to be(false)
+      end
+
+      it 'is never due at a weekend' do
+        expect(described_class.due?(now: Time.zone.parse('2026-07-26 15:30'))).to be(false)
+      end
+    end
+  end
+
+  describe Paper::DayRollover do
+    before { account.update!(last_rolled_on: 2.days.ago.to_date) }
+
+    it 'expires a DAY order left resting from a previous session' do
+      order = resting_order
+
+      described_class.ensure!(account: account)
+
+      expect(order.reload.status).to eq('expired')
+    end
+
+    it 'returns the margin an expiring order had blocked' do
+      account.update!(blocked_margin: 3_000, utilized_margin: 3_000)
+      resting_order(metadata: { 'blocked_margin' => 3_000 })
+
+      described_class.ensure!(account: account)
+
+      expect(account.reload.blocked_margin.to_f).to eq(0.0)
+    end
+
+    it 'does nothing twice in one day' do
+      expect(described_class.ensure!(account: account)).to be(true)
+      expect(described_class.ensure!(account: account.reload)).to be(false)
+    end
+
+    # A book that has never been rolled is starting its first session, not
+    # recovering from a missed one.
+    it 'treats a fresh book as already current' do
+      account.update!(last_rolled_on: nil)
+      order = resting_order
+
+      expect(described_class.ensure!(account: account)).to be(false)
+      expect(order.reload.status).to eq('pending')
+      expect(account.reload.last_rolled_on).to eq(Time.current.in_time_zone(described_class::ZONE).to_date)
+    end
+  end
+end

--- a/spec/services/paper/exchange_spec.rb
+++ b/spec/services/paper/exchange_spec.rb
@@ -264,6 +264,70 @@ RSpec.describe Paper::Exchange do
 
       expect(account.paper_orders.where(order_category: 'super').first.reload.status).to eq('traded')
     end
+
+    # A trailing_jump that is recorded and then ignored makes every trailing
+    # strategy test as a fixed stop: it never gives back the move, so anything
+    # that rides a trend and hands profit back looks better than it was.
+    describe 'trailing stop' do
+      let(:trailing_entry) do
+        buy_market.merge(order_type: 'LIMIT', price: 1_500.0, target_price: 1_600.0,
+                         stop_loss_price: 1_470.0, trailing_jump: 10.0)
+      end
+
+      def tick(price)
+        Live::TickCache.put('NSE_EQ', '1333', ltp: price)
+        exchange.process_tick(security_id: '1333', exchange_segment: 'NSE_EQ', ltp: price)
+      end
+
+      it 'ratchets the stop up in whole jumps as price advances' do
+        exchange.place(trailing_entry)
+
+        tick(1_525.0) # +25 from entry: two whole jumps
+
+        entry = account.paper_orders.where(order_category: 'super').first.reload
+        expect(entry.metadata['trailed_stop'].to_f).to eq(1_490.0)
+      end
+
+      it 'does not move the stop until price travels a full jump' do
+        exchange.place(trailing_entry)
+
+        tick(1_508.0)
+
+        expect(account.paper_orders.where(order_category: 'super').first.reload.metadata['trailed_stop']).to be_nil
+      end
+
+      it 'never gives the stop back when price retreats' do
+        exchange.place(trailing_entry)
+
+        tick(1_530.0)
+        tick(1_505.0)
+
+        entry = account.paper_orders.where(order_category: 'super').first.reload
+        expect(entry.metadata['trailed_stop'].to_f).to eq(1_500.0)
+        expect(entry.status).to eq('traded')
+      end
+
+      it 'exits on the trailed stop, well above the original one' do
+        exchange.place(trailing_entry)
+
+        tick(1_530.0)  # stop trails to 1500
+        tick(1_499.0)  # through the trailed stop, nowhere near the original 1470
+
+        entry = account.paper_orders.where(order_category: 'super').first.reload
+        expect(entry.metadata['exit_leg']).to eq('STOP_LOSS')
+        expect(account.paper_positions.find_by(security_id: '1333').net_qty).to eq(0)
+      end
+
+      it 'trails downward for a short' do
+        exchange.place(buy_market.merge(transaction_type: 'SELL', order_type: 'LIMIT', price: 1_500.0,
+                                        target_price: 1_400.0, stop_loss_price: 1_530.0, trailing_jump: 10.0))
+
+        tick(1_475.0) # -25 from entry: two whole jumps
+
+        entry = account.paper_orders.where(order_category: 'super').first.reload
+        expect(entry.metadata['trailed_stop'].to_f).to eq(1_510.0)
+      end
+    end
   end
 
   describe 'partial fills' do

--- a/spec/services/paper/feed_subscriber_spec.rb
+++ b/spec/services/paper/feed_subscriber_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Paper::FeedSubscriber do
+  let(:account) do
+    PaperAccount.create!(initial_capital: 1_000_000, available_balance: 1_000_000,
+                         config: PaperAccount::DEFAULT_CONFIG.dup)
+  end
+  let(:hub) { instance_double(Live::MarketFeedHub) }
+
+  before { allow(Live::MarketFeedHub).to receive(:instance).and_return(hub) }
+
+  describe '.follow' do
+    it 'subscribes the instrument when the feed is running' do
+      allow(hub).to receive_messages(running?: true, subscribe: true)
+
+      expect(described_class.follow(segment: 'NSE_FNO', security_id: '49081')).to be(true)
+      expect(hub).to have_received(:subscribe).with(segment: 'NSE_FNO', security_id: '49081')
+    end
+
+    # A web process that never started a feed still places paper orders; it
+    # must not be dragged into starting one, and must not raise.
+    it 'does nothing when no feed is running in this process' do
+      allow(hub).to receive(:running?).and_return(false)
+      allow(hub).to receive(:subscribe)
+
+      expect(described_class.follow(segment: 'NSE_FNO', security_id: '49081')).to be(false)
+      expect(hub).not_to have_received(:subscribe)
+    end
+
+    it 'swallows a feed failure rather than failing the placement' do
+      allow(hub).to receive(:running?).and_return(true)
+      allow(hub).to receive(:subscribe).and_raise(StandardError, 'socket gone')
+
+      expect(described_class.follow(segment: 'NSE_FNO', security_id: '49081')).to be(false)
+    end
+  end
+
+  describe '.restore_book!' do
+    before { allow(hub).to receive_messages(running?: true, subscribe: true) }
+
+    it 'subscribes resting orders and open positions, without duplicates' do
+      account.paper_orders.create!(
+        security_id: '49081', exchange_segment: 'NSE_FNO', transaction_type: 'BUY',
+        order_type: 'LIMIT', product_type: 'MARGIN', quantity: 75, price: 100, status: 'pending'
+      )
+      account.paper_positions.create!(
+        security_id: '49081', exchange_segment: 'NSE_FNO', product_type: 'MARGIN',
+        position_type: 'LONG', net_qty: 75
+      )
+      account.paper_positions.create!(
+        security_id: '1333', exchange_segment: 'NSE_EQ', product_type: 'INTRADAY',
+        position_type: 'LONG', net_qty: 10
+      )
+
+      expect(described_class.restore_book!(account: account)).to eq(2)
+      expect(hub).to have_received(:subscribe).with(segment: 'NSE_FNO', security_id: '49081').once
+      expect(hub).to have_received(:subscribe).with(segment: 'NSE_EQ', security_id: '1333').once
+    end
+
+    it 'ignores orders that are already done and positions that are flat' do
+      account.paper_orders.create!(
+        security_id: '49081', exchange_segment: 'NSE_FNO', transaction_type: 'BUY',
+        order_type: 'MARKET', product_type: 'MARGIN', quantity: 75, status: 'traded'
+      )
+      account.paper_positions.create!(
+        security_id: '1333', exchange_segment: 'NSE_EQ', product_type: 'INTRADAY',
+        position_type: 'CLOSED', net_qty: 0
+      )
+
+      expect(described_class.restore_book!(account: account)).to eq(0)
+    end
+  end
+end

--- a/spec/services/paper/positions_dhan_shaped_spec.rb
+++ b/spec/services/paper/positions_dhan_shaped_spec.rb
@@ -52,11 +52,33 @@ RSpec.describe Paper::Positions, '.dhan_shaped' do
     expect(losses).to eq(-4_000.0)
   end
 
-  # Dhan's positions API is day-scoped; the simulated book must be too, or a
-  # loss from last week keeps blocking today's entries.
-  it 'excludes rows untouched today' do
-    travel_to(3.days.ago) { create_position(security_id: '49083') }
+  # Dhan's positions API is day-scoped, and the rollover is what makes the
+  # simulated book day-scoped too. A flat row from a previous session is gone;
+  # an open carry-forward position is still today's business, exactly as the
+  # broker reports it.
+  context 'across a session boundary' do
+    before { account.update!(last_rolled_on: 3.days.ago.to_date) }
 
-    expect(described_class.dhan_shaped.pluck('securityId')).not_to include('49083')
+    it 'drops a position that was already flat' do
+      travel_to(3.days.ago) do
+        create_position(security_id: '49083', position_type: 'CLOSED', net_qty: 0, realized_profit: -500.0)
+      end
+
+      expect(described_class.dhan_shaped.pluck('securityId')).not_to include('49083')
+    end
+
+    it 'keeps an open carry-forward position' do
+      travel_to(3.days.ago) { create_position(security_id: '49084') }
+
+      expect(described_class.dhan_shaped.pluck('securityId')).to include('49084')
+    end
+
+    # Yesterday's realised loss is not today's, and the daily-loss guard reads
+    # this figure.
+    it 'clears realised P&L carried in from the previous session' do
+      travel_to(3.days.ago) { create_position(security_id: '49085', realized_profit: -9_000.0) }
+
+      expect(described_class.dhan_shaped.sum { |p| p['realizedProfit'].to_f }).to eq(0.0)
+    end
   end
 end

--- a/spec/services/paper/positions_dhan_shaped_spec.rb
+++ b/spec/services/paper/positions_dhan_shaped_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Paper::Positions, '.dhan_shaped' do
+  let!(:account) do
+    PaperAccount.create!(initial_capital: 1_000_000, available_balance: 1_000_000,
+                         config: PaperAccount::DEFAULT_CONFIG.dup)
+  end
+
+  def create_position(**attrs)
+    account.paper_positions.create!(
+      { security_id: '49081', exchange_segment: 'NSE_FNO', product_type: 'MARGIN',
+        trading_symbol: 'NIFTY24JUL22000CE', position_type: 'LONG', net_qty: 75,
+        buy_qty: 75, buy_avg: 100.0, realized_profit: 0.0, unrealized_profit: 250.0, ltp: 103.0 }.merge(attrs)
+    )
+  end
+
+  # Callers across this app reach for camelCase and snake_case interchangeably;
+  # answering only one spelling reads as a flat position, which is how a paper
+  # run silently places the same entry twice.
+  it 'answers both the broker spelling and the snake_case one' do
+    create_position
+
+    row = described_class.dhan_shaped.first
+
+    expect(row['securityId']).to eq('49081')
+    expect(row['security_id']).to eq('49081')
+    expect(row['netQty']).to eq(75)
+    expect(row['positionType']).to eq('LONG')
+    expect(row['exchangeSegment']).to eq('NSE_FNO')
+    expect(row['realizedProfit']).to eq(0.0)
+  end
+
+  it 'is readable with symbol keys too' do
+    create_position
+
+    row = described_class.dhan_shaped.first
+
+    expect(row[:security_id]).to eq('49081')
+    expect(row[:securityId]).to eq('49081')
+  end
+
+  # Realised P&L lives on the row that closed, so excluding closed positions
+  # would leave the daily-loss guard permanently reading zero.
+  it 'includes closed positions so realised losses stay visible' do
+    create_position(security_id: '49082', position_type: 'CLOSED', net_qty: 0,
+                    realized_profit: -4_000.0, unrealized_profit: 0.0)
+
+    losses = described_class.dhan_shaped.sum { |p| p['realizedProfit'].to_f }
+
+    expect(losses).to eq(-4_000.0)
+  end
+
+  # Dhan's positions API is day-scoped; the simulated book must be too, or a
+  # loss from last week keeps blocking today's entries.
+  it 'excludes rows untouched today' do
+    travel_to(3.days.ago) { create_position(security_id: '49083') }
+
+    expect(described_class.dhan_shaped.pluck('securityId')).not_to include('49083')
+  end
+end

--- a/spec/services/positions/source_spec.rb
+++ b/spec/services/positions/source_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Positions::Source do
+  let!(:account) do
+    PaperAccount.create!(initial_capital: 1_000_000, available_balance: 1_000_000,
+                         config: PaperAccount::DEFAULT_CONFIG.dup)
+  end
+
+  around do |example|
+    original = ENV.fetch('PAPER_TRADING', nil)
+    ENV['PAPER_TRADING'] = paper_enabled
+    example.run
+    ENV['PAPER_TRADING'] = original
+  end
+
+  def create_position(**attrs)
+    account.paper_positions.create!(
+      { security_id: '1333', exchange_segment: 'NSE_EQ', product_type: 'INTRADAY',
+        position_type: 'LONG', net_qty: 10, buy_qty: 10, buy_avg: 1_400.0 }.merge(attrs)
+    )
+  end
+
+  # The exit stack reads positions through here. Pointed at the live book during
+  # a paper run it manages an empty account: no trailing stop, no risk exit,
+  # nothing, while simulated positions run unattended.
+  context 'when paper trading is enabled' do
+    let(:paper_enabled) { 'true' }
+
+    it 'serves the paper book' do
+      create_position
+      allow(DhanHQ::Models::Position).to receive(:all)
+      rows = described_class.all
+
+      expect(rows.pluck('securityId')).to eq(['1333'])
+      expect(DhanHQ::Models::Position).not_to have_received(:all)
+    end
+
+    it 'drops flat positions from the open view' do
+      create_position(position_type: 'CLOSED', net_qty: 0)
+
+      expect(described_class.open).to be_empty
+    end
+
+    # Orders::Analyzer prices P&L off costPrice; without it a paper position
+    # analyses as worthless and is skipped by the exit stack.
+    it 'carries the entry price the analyzer needs' do
+      create_position
+      rows = described_class.all
+
+      expect(rows.first['costPrice']).to eq(1_400.0)
+    end
+  end
+
+  context 'when paper trading is disabled' do
+    let(:paper_enabled) { 'false' }
+
+    it 'serves the broker book' do
+      allow(DhanHQ::Models::Position).to receive(:all).and_return([])
+
+      expect(described_class.all).to eq([])
+      expect(DhanHQ::Models::Position).to have_received(:all)
+    end
+  end
+end


### PR DESCRIPTION
Three defects meant a paper run either never happened or reported numbers
that were not the simulation's.

Index options never reached the simulator. AlertProcessors::Index checked
Orders::Gateway.place_order_enabled? and returned a dry run before calling
the gateway — but the gateway routes to Paper::Exchange *ahead* of the
PLACE_ORDER/LIVE_TRADING gates, so with the live gates off (the only sane
paper configuration) every index alert was recorded as skipped and nothing
was ever filled. McxCommodity inherits the path and was blocked with it.
The processor now always hands the order over and branches on the result,
which also distinguishes a gate-blocked order from a rejected one instead
of logging both as "PLACE_ORDER disabled".

Only the write side was papered. Sizing read the live account's funds and
every guard — entry dedupe, flips, exits, the daily-loss cap — read the
live position book, which is empty during a paper run: repeated signals
stacked duplicate positions, exits found nothing to close, and the daily
loss guard always saw zero. AlertProcessors::Base#available_balance and
#dhan_positions now serve the paper book, the latter through a new
Paper::Positions.dhan_shaped that answers both the broker's camelCase keys
and snake_case. Both daily-loss guards read it rather than the SDK, with
the cache key scoped per book.

Nothing subscribed the feed to what was being traded. The feed is the
matching engine's clock, and an option strike is not known until the alert
arrives, so resting orders never filled and positions never marked unless
the instrument happened to be in SYMBOLS. Paper::FeedSubscriber follows
each instrument as it is traded and restores the open book on live:feed
start.

Also fixes an exit that went out with a nil quantity: Dhan reports netQty,
not quantity, and IndexPositionManager read only the latter.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DbD4p8GH1fYhmLhcwVemkt