### PR TITLE
Stop verifying the database TLS certificate by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,17 @@ redeploy with nothing to do all behave correctly.
   `db/schema.rb` when there is nothing to migrate from, and is a no-op once the
   schema is current.
 - **Database steps retry** with exponential backoff, because a managed instance
-  can refuse connections for a few seconds after it wakes.
+  can refuse connections for a few seconds after it wakes. A failure that a
+  retry cannot fix — a certificate that will not verify, a rejected password —
+  aborts on the first attempt with the setting to change, instead of printing
+  the same error five times.
+- **The database connection is encrypted but not verified** by default
+  (`sslmode: require`). A managed instance on the provider's private network
+  presents a certificate from the provider's own CA on an address that
+  certificate does not name, so verification cannot succeed against the system
+  trust store. Set `DATABASE_SSLMODE=verify-full` together with
+  `DATABASE_SSLROOTCERT=/path/to/ca.crt` to verify; an `sslmode` already in
+  `DATABASE_URL` wins over both.
 - **Seeds run every deploy** — `db/seeds.rb` skips what already exists. Opt out
   with `SKIP_SEEDS_ON_DEPLOY=true`.
 - **Optional steps never fail the build.** Instrument imports are opt-in
@@ -394,7 +404,7 @@ Things that previously broke the deploy, and where they are fixed:
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `root certificate file "/opt/render/.postgresql/root.crt" does not exist` | Managed Postgres/Cockroach verifies TLS against a cert file that isn't on the instance | `DATABASE_SSLMODE=verify-full` + `sslrootcert: system` in `config/database.yml` |
+| `SSL error: certificate verify failed` / `root certificate file "/opt/render/.postgresql/root.crt" does not exist` | TLS verification against a managed instance: the certificate comes from the provider's own CA, and the internal endpoint answers on a private address it does not name, so neither the issuer nor the hostname checks out | `config/database.yml` defaults to `sslmode: require` — encrypted, unverified. To verify, set `DATABASE_SSLMODE=verify-full` **and** `DATABASE_SSLROOTCERT` to the CA bundle the provider publishes |
 | `expected .../DhanHQ/mcp.rb to define constant DhanHQ::Mcp` | `eager_load` in production force-loads gem Zeitwerk loaders, and the gem's filenames don't resolve | `config/initializers/dhanhq_eager_load.rb` excludes the gem from eager loading; its constants stay autoloadable |
 | `KeyError: key not found: "OPENAI_API_KEY"` | Initializer used a bare `ENV.fetch` | Missing key now fails on the call that needs it, not at boot |
 | Deploy live but unhealthy | No `healthCheckPath`, server not bound to `$PORT` | `healthCheckPath: /up` and an explicit Puma bind |

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -22,16 +22,55 @@ log()  { printf '\n\033[1m%s\033[0m\n' "$*"; }
 warn() { printf '\033[33m⚠ %s\033[0m\n' "$*"; }
 ok()   { printf '\033[32m✔ %s\033[0m\n' "$*"; }
 
+# Some database failures are settled before the first packet: a certificate
+# that cannot verify, or a password the server rejects, fails identically on
+# every attempt. Retrying those spends 30 seconds and buries the real error
+# under four copies of itself, so they abort straight away with the setting to
+# change. Anything else is treated as transient and retried.
+explain_db_failure() {
+  local log_file=$1
+
+  if grep -Eq 'certificate verify failed|root certificate file|sslmode|SSL error' "$log_file"; then
+    cat <<'EOF'
+  The TLS handshake with the database failed.
+
+  config/database.yml encrypts the connection without verifying the server
+  certificate unless DATABASE_SSLMODE says otherwise. If it is set to verify-ca
+  or verify-full, either drop it or set DATABASE_SSLROOTCERT to the CA bundle
+  your provider publishes — a managed instance reached over a private network
+  is signed by the provider's own CA and answers on an address its certificate
+  does not name, so neither check can pass against the system trust store.
+EOF
+    return 0
+  fi
+
+  if grep -Eq 'password authentication failed|role .* does not exist' "$log_file"; then
+    echo '  The database rejected the credentials in DATABASE_URL.'
+    return 0
+  fi
+
+  return 1
+}
+
 # Runs a command, retrying with exponential backoff. Used for anything that
 # touches the database: a managed instance can refuse connections for the first
 # few seconds after it wakes, which is not a reason to fail a deploy.
 retry() {
   local attempts=$1 description=$2; shift 2
-  local attempt=1 delay=2
+  local attempt=1 delay=2 log_file hint
+  log_file=$(mktemp)
 
-  until "$@"; do
+  until "$@" 2>&1 | tee "$log_file"; do
+    if hint=$(explain_db_failure "$log_file"); then
+      printf '\033[31m✖ %s failed for a reason retrying cannot fix\033[0m\n' "$description"
+      printf '%s\n' "$hint"
+      rm -f "$log_file"
+      return 1
+    fi
+
     if (( attempt >= attempts )); then
       printf '\033[31m✖ %s failed after %d attempts\033[0m\n' "$description" "$attempts"
+      rm -f "$log_file"
       return 1
     fi
     warn "$description failed (attempt ${attempt}/${attempts}); retrying in ${delay}s"
@@ -39,6 +78,8 @@ retry() {
     attempt=$(( attempt + 1 ))
     delay=$(( delay * 2 ))
   done
+
+  rm -f "$log_file"
 }
 
 # For steps whose failure should be reported but must not fail the deploy.

--- a/config/database.yml
+++ b/config/database.yml
@@ -79,54 +79,47 @@ test:
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #
-production:
-  primary: &primary_production
-    adapter: postgresql
-    encoding: unicode
-    url: <%= ENV['DATABASE_URL'] %>
-  cache:
-    <<: *primary_production
-    database: algo_trading_app_production_cache
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *primary_production
-    database: algo_trading_app_production_queue
-    migrations_paths: db/queue_migrate
-  cable:
-    <<: *primary_production
-    database: algo_trading_app_production_cable
-    migrations_paths: db/cable_migrate
 
 # ---------------------------------------------------------------------------
 # Production
 #
-# There was no production entry here at all, so every setting had to be
-# inferred from DATABASE_URL alone — and the entries below could not be
-# expressed, which is why config/cable.yml's `database: cable` and
-# production.rb's `solid_queue.connects_to` had nothing to resolve against.
+# Everything beyond DATABASE_URL is configured here, including the cache, queue
+# and cable entries that config/cable.yml's `database: cable` and production.rb's
+# `solid_queue.connects_to` reference. They point at the same database as the
+# primary and are marked database_tasks: false so db:prepare prepares it once.
 #
-# sslmode/sslrootcert matter for a managed provider that terminates TLS with a
-# public CA (Render Postgres, Cockroach Cloud, Neon, Supabase). Without them
-# libpq looks for ~/.postgresql/root.crt, which does not exist on a Render
-# instance, and the connection fails before a single query:
+# TLS: the connection is encrypted but the server certificate is not verified
+# by default. Verification needs both a trusted issuer and a matching hostname,
+# and a managed instance reached over the provider's private network has
+# neither — Render Postgres issues its certificate from Render's own CA and the
+# internal endpoint resolves to a private address, so verify-full against the
+# system trust store dies before the first query:
 #
-#   root certificate file "/opt/render/.postgresql/root.crt" does not exist
+#   SSL error: certificate verify failed
 #
-# `sslrootcert: system` verifies against the OS trust store instead. Both are
-# overridable per environment, and anything already present in DATABASE_URL
-# wins, so a provider needing a bundled cert is unaffected.
+# To verify, set DATABASE_SSLMODE=verify-full and point DATABASE_SSLROOTCERT at
+# the CA bundle the provider publishes (Cockroach Cloud and Supabase ship one;
+# `system` uses the OS trust store and only works for a publicly signed cert on
+# its public hostname). DATABASE_SSLMODE=disable is for a local proxy that has
+# already terminated TLS.
+#
+# An sslmode carried in DATABASE_URL wins over the value below — Rails merges
+# the URL's query parameters on top of this file — so a provider whose
+# connection string already says verify-full keeps verifying.
 # ---------------------------------------------------------------------------
 production:
   primary: &primary_production
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>
-    <%# libpq rejects sslrootcert alongside a non-verifying sslmode ("weak      %>
-    <%# sslmode 'disable' may not be used with sslrootcert=system"), so the     %>
-    <%# cert setting is emitted only for the modes that actually verify.        %>
-    <% ssl_mode = ENV.fetch('DATABASE_SSLMODE', 'verify-full') %>
+    <%# libpq rejects sslrootcert alongside a mode that does not verify ("weak  %>
+    <%# sslmode 'require' may not be used with sslrootcert=system"), and takes  %>
+    <%# the 'system' keyword only under verify-full, so the cert setting is     %>
+    <%# emitted only where libpq accepts it.                                    %>
+    <% ssl_mode = ENV.fetch('DATABASE_SSLMODE', 'require') %>
+    <% ssl_root_cert = ENV['DATABASE_SSLROOTCERT'] || ('system' if ssl_mode == 'verify-full') %>
     sslmode: <%= ssl_mode %>
-    <% if ssl_mode.start_with?('verify') %>
-    sslrootcert: <%= ENV.fetch('DATABASE_SSLROOTCERT', 'system') %>
+    <% if ssl_root_cert && ssl_mode.start_with?('verify') %>
+    sslrootcert: <%= ssl_root_cert %>
     <% end %>
   cache:
     <<: *primary_production

--- a/render.yaml
+++ b/render.yaml
@@ -26,14 +26,18 @@ services:
           name: AlgoTradingAPI-DB
           property: connectionString
 
-      # Managed Postgres and Cockroach terminate TLS with a public CA. Without
-      # this libpq looks for ~/.postgresql/root.crt, which does not exist on a
-      # Render instance, and the build dies before the first query:
-      #   root certificate file "/opt/render/.postgresql/root.crt" does not exist
-      # Use `require` to encrypt without verifying, or `disable` behind a local
-      # proxy.
+      # Encrypt the database connection without verifying the certificate.
+      # This is the default in config/database.yml; it is repeated here so a
+      # blueprint sync clears a verify-full left over in the dashboard, which
+      # fails against a Render database on every deploy:
+      #   SSL error: certificate verify failed
+      # Render issues the certificate from its own CA and the internal endpoint
+      # answers on a private address the certificate does not name, so the
+      # system trust store can verify neither. To verify anyway, set
+      # verify-full here and DATABASE_SSLROOTCERT to the provider's CA bundle.
+      # `disable` is for a local proxy that already terminated TLS.
       - key: DATABASE_SSLMODE
-        value: verify-full
+        value: require
 
       - key: RAILS_ENV
         value: production


### PR DESCRIPTION
Every deploy died before the first query:

  SSL error: certificate verify failed

config/database.yml defaulted to sslmode verify-full with sslrootcert=system,
which cannot succeed against a managed instance on the provider's private
network. Verification needs a trusted issuer and a matching hostname, and
Render Postgres has neither: the certificate is issued by Render's own CA,
absent from the OS trust store, and the internal endpoint answers on a private
address the certificate does not name. The earlier root.crt failure that
verify-full was meant to fix came from the *previous* database, whose URL
carried its own sslmode; the setting was never needed for Render's.

The default is now `require` — the connection is still encrypted, the
certificate is simply not checked. Verification stays available for a provider
that publishes a CA bundle: DATABASE_SSLMODE=verify-full plus
DATABASE_SSLROOTCERT=/path/to/ca.crt. sslrootcert is emitted only where libpq
accepts it — the `system` keyword is rejected under any mode weaker than
verify-full ("weak sslmode 'verify-ca' may not be used with
sslrootcert=system"), so it now defaults in for verify-full alone rather than
every verify-* mode. An sslmode carried in DATABASE_URL still wins over all of
this, since Rails merges the URL's query parameters over the file.

render.yaml pins DATABASE_SSLMODE=require rather than dropping the key, so a
blueprint sync clears a verify-full still set in the dashboard.

Also removed the duplicate production: block. There were two, with the same
&primary_production anchor; the first was dead — YAML keeps the last — and its
cache/queue/cable entries named databases that do not exist.

bin/render-build.sh retried this five times over 30 seconds and printed the
same error five times. Database failures that a retry cannot fix — a
certificate that will not verify, rejected credentials — now abort on the
first attempt and name the setting to change.

Verified against a local Postgres serving a self-signed certificate on an
address the certificate does not name, connecting through this database.yml
via ActiveRecord: the old default reproduces the deploy error exactly, the new
default connects over TLS 1.3, verify-full with the CA bundle and a matching
hostname connects and verifies, and an sslmode in DATABASE_URL overrides the
file. Both retry paths exercised: the TLS failure aborts in 13ms, a transient
connection refusal still recovers on the third attempt.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A74CcMXMiKebTPVLWwYFqL