### PR TITLE
Normalize the instrument master and index its hot lookups

### DIFF
--- a/app/ai/tools/dhan_candle_tool.rb
+++ b/app/ai/tools/dhan_candle_tool.rb
@@ -15,8 +15,10 @@ module AI
         sym = symbol.to_s.upcase
         lim = [limit.to_i.positive? ? limit.to_i : 20, 100].min
 
+        # There is no `trading_symbol` column on instruments; the detailed
+        # scrip master's symbol lands in `symbol_name`.
         instrument = Instrument.segment_index.find_by(underlying_symbol: sym) ||
-                     Instrument.find_by(trading_symbol: sym)
+                     Instrument.find_by(symbol_name: sym)
 
         return { error: "Instrument not found: #{sym}" } unless instrument
 

--- a/app/models/concerns/instrument_helper.rb
+++ b/app/models/concerns/instrument_helper.rb
@@ -4,8 +4,17 @@
 module InstrumentHelper
   extend ActiveSupport::Concern
 
-  # Generate `exchange_segment` dynamically based on exchange and segment enums
+  # Prefer the stored generated column, which Postgres maintains from
+  # (exchange, segment) and which the lookup indexes are built on, so this
+  # cannot disagree with what a query matched. The case statement stays as the
+  # fallback for records not loaded from the table.
+  #
+  # This concern is included after InstrumentHelpers, so it shadows that
+  # module's identically named method — it has to do the same column check or
+  # Instrument would silently lose it.
   def exchange_segment
+    return self[:exchange_segment] if has_attribute?(:exchange_segment) && self[:exchange_segment].present?
+
     case [exchange.to_sym, segment.to_sym]
     when %i[nse index], %i[bse index] then 'IDX_I'
     when %i[nse equity] then 'NSE_EQ'

--- a/app/models/derivative.rb
+++ b/app/models/derivative.rb
@@ -1,13 +1,21 @@
 # frozen_string_literal: true
 
-# Represents a derivative financial instrument tied to an underlying asset.
+# A single tradable derivative contract (option or future) from the DhanHQ
+# scrip master, optionally linked to the Instrument that is its underlying.
 class Derivative < ApplicationRecord
   include InstrumentHelpers
 
+  OPTION_TYPES = %w[CE PE].freeze
+
   # Associations
-  belongs_to :instrument
-  has_many :margin_requirements, as: :requirementable, dependent: :destroy
-  has_many :order_features, as: :featureable, dependent: :destroy
+  #
+  # Optional: a contract is tradable whether or not we have matched its
+  # underlying in `instruments`. While this was required, the importer dropped
+  # every derivative whose underlying was missing from the master rather than
+  # storing it unparented.
+  belongs_to :instrument, optional: true
+  has_one :margin_requirement, as: :requirementable, dependent: :destroy, inverse_of: :requirementable
+  has_one :order_feature, as: :featureable, dependent: :destroy, inverse_of: :featureable
   has_many :watchlist_items, as: :watchable, dependent: :nullify, inverse_of: :watchable
   # Scoped view over the rows already owned by :watchlist_items above, so it
   # carries the same :dependent option.
@@ -16,5 +24,74 @@ class Derivative < ApplicationRecord
   has_many :position_trackers, as: :watchable, dependent: :destroy
 
   # Validations
-  validates :strike_price, :option_type, :expiry_date, presence: true
+  #
+  # Only options carry a strike and a CE/PE type; futures are derivatives too
+  # and were rejected outright by the previous unconditional presence checks.
+  # (Import goes through activerecord-import, which skips validations, so the
+  # old rule silently applied to hand-built records only.)
+  validates :security_id, presence: true
+  validates :expiry_date, presence: true
+  validates :option_type, inclusion: { in: OPTION_TYPES }, allow_nil: true
+  validates :strike_price, :option_type, presence: true, if: :option?
+
+  # Scopes
+  scope :active, -> { where(active: true) }
+  scope :options, -> { where(option_type: OPTION_TYPES) }
+  scope :futures, -> { where(option_type: [nil, '']) }
+  scope :calls, -> { where(option_type: 'CE') }
+  scope :puts, -> { where(option_type: 'PE') }
+  scope :not_seen_since, ->(time) { where(last_seen_at: ...time) }
+  scope :expiring_on, ->(date) { where(expiry_date: date) }
+  scope :unexpired, -> { where(expiry_date: Date.current..) }
+
+  # The one query the option-buying path runs over and over. Column order
+  # matches index_derivatives_on_options_chain, so this is an index-ordered
+  # range scan rather than a filter over the whole expiry.
+  scope :options_chain, lambda { |underlying, expiry_date|
+    active.where(underlying_symbol: underlying.to_s.upcase, expiry_date: expiry_date)
+      .where(option_type: OPTION_TYPES)
+      .order(:strike_price, :option_type)
+  }
+
+  # Backed by index_derivatives_on_segment_and_security_id.
+  def self.for_tick(exchange_segment:, security_id:)
+    find_by(exchange_segment: exchange_segment.to_s, security_id: security_id.to_s)
+  end
+
+  # Distinct expiries still available for an underlying, nearest first.
+  def self.expiries_for(underlying)
+    active.where(underlying_symbol: underlying.to_s.upcase)
+      .where(expiry_date: Date.current..)
+      .distinct
+      .order(:expiry_date)
+      .pluck(:expiry_date)
+  end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[
+      security_id symbol_name display_name underlying_symbol instrument_code
+      instrument_type exchange segment exchange_segment expiry_date
+      strike_price option_type expiry_flag active created_at updated_at
+    ]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[instrument margin_requirement order_feature]
+  end
+
+  def option?
+    OPTION_TYPES.include?(option_type.to_s.upcase)
+  end
+
+  def call?
+    option_type.to_s.upcase == 'CE'
+  end
+
+  def put?
+    option_type.to_s.upcase == 'PE'
+  end
+
+  def expired?
+    expiry_date.present? && expiry_date < Date.current
+  end
 end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -8,8 +8,12 @@ class Instrument < ApplicationRecord
   # Associations
   has_one :mis_detail, dependent: :destroy
   has_many :derivatives, dependent: :destroy
-  has_many :margin_requirements, as: :requirementable, dependent: :destroy
-  has_many :order_features, as: :featureable, dependent: :destroy
+  # Both satellites are 1:1 — the DB enforces it with a unique index on the
+  # polymorphic pair — so they are has_one, not has_many. They were declared
+  # has_many while `ransackable_associations` already named them in the
+  # singular, so association search never resolved.
+  has_one :margin_requirement, as: :requirementable, dependent: :destroy, inverse_of: :requirementable
+  has_one :order_feature, as: :featureable, dependent: :destroy, inverse_of: :featureable
   has_many :alerts, dependent: :destroy
   has_many :levels, dependent: :destroy
   has_many :quotes, dependent: :destroy
@@ -22,8 +26,8 @@ class Instrument < ApplicationRecord
 
   # Enable nested attributes for associated models
   accepts_nested_attributes_for :derivatives, allow_destroy: true
-  accepts_nested_attributes_for :margin_requirements, allow_destroy: true
-  accepts_nested_attributes_for :order_features, allow_destroy: true
+  accepts_nested_attributes_for :margin_requirement, allow_destroy: true
+  accepts_nested_attributes_for :order_feature, allow_destroy: true
 
   # Enums (explicit attribute types for Rails 8)
   #
@@ -41,8 +45,32 @@ class Instrument < ApplicationRecord
   # and silently discards the enum's value mapping.
 
   # Validations
-  validates :security_id, presence: true, uniqueness: true
+  #
+  # A DhanHQ security_id is unique *within* an exchange segment, not globally —
+  # NSE_EQ 2885 and IDX_I 2885 are different instruments. The previous global
+  # uniqueness rejected legitimate rows on any manual create and scanned the
+  # whole table to do it.
+  validates :security_id, presence: true, uniqueness: { scope: %i[exchange segment] }
   validates :symbol_name, presence: true
+
+  # Scopes
+  scope :active, -> { where(active: true) }
+  scope :inactive, -> { where(active: false) }
+  # Not seen in the most recent scrip master, so the exchange has stopped
+  # listing it. Kept rather than deleted because orders and positions still
+  # reference these rows by security_id.
+  scope :not_seen_since, ->(time) { where(last_seen_at: ...time) }
+  scope :for_segment, ->(segment) { where(exchange_segment: segment.to_s) }
+  scope :tradable, lambda {
+    active.left_joins(:order_feature)
+      .where(order_features: { asm_gsm_flag: [nil, 'N', 'R'] })
+  }
+
+  # The pair every DhanHQ payload and every WebSocket tick is addressed by.
+  # Backed by index_instruments_on_segment_and_security_id.
+  def self.for_tick(exchange_segment:, security_id:)
+    find_by(exchange_segment: exchange_segment.to_s, security_id: security_id.to_s)
+  end
 
   # Class Methods
   SEGMENT_FROM_EXCHANGE = {
@@ -91,6 +119,8 @@ class Instrument < ApplicationRecord
       display_name
       exchange
       segment
+      exchange_segment
+      active
       created_at
       updated_at
     ]

--- a/app/models/instrument_sync_run.rb
+++ b/app/models/instrument_sync_run.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# One row per scrip-master import, replacing the loose `app_settings` strings
+# the importer used to write. Keeps history, records failures, and makes
+# "is the instrument master stale?" a query rather than a string comparison.
+class InstrumentSyncRun < ApplicationRecord
+  STALE_AFTER = 24.hours
+
+  enum :status, { running: 'running', succeeded: 'succeeded', failed: 'failed' }, prefix: true
+  enum :source, { url: 'url', file: 'file', inline: 'inline' }, prefix: true
+
+  validates :started_at, presence: true
+
+  scope :recent, -> { order(started_at: :desc) }
+
+  def self.last_success
+    status_succeeded.recent.first
+  end
+
+  # True when no import has succeeded inside STALE_AFTER. Callers that size
+  # positions off `lot_size` or resolve expiries should refuse rather than
+  # trade against a master that may predate an expiry roll.
+  def self.stale?
+    run = last_success
+    run.nil? || run.finished_at.nil? || run.finished_at < STALE_AFTER.ago
+  end
+
+  def duration
+    return nil unless started_at && finished_at
+
+    finished_at - started_at
+  end
+
+  def succeed!(**counts)
+    update!(counts.merge(status: 'succeeded', finished_at: Time.current))
+  end
+
+  def fail!(error)
+    update!(status: 'failed', finished_at: Time.current, error_message: error.to_s.truncate(2_000))
+  end
+end

--- a/app/models/order_feature.rb
+++ b/app/models/order_feature.rb
@@ -1,9 +1,36 @@
 # frozen_string_literal: true
 
+# Per-instrument tradability facts from the scrip master: whether bracket and
+# cover orders are accepted, which sides may be traded, the exchange's ASM/GSM
+# surveillance status and the MTF leverage on offer.
+#
+# Owned polymorphically by Instrument and Derivative — these columns used to be
+# duplicated onto both wide tables and left almost entirely NULL.
 class OrderFeature < ApplicationRecord
   # Associations
   belongs_to :featureable, polymorphic: true
 
   # Validations
   validates :bracket_flag, :cover_flag, inclusion: { in: %w[Y N] }, allow_nil: true
+  # The exchange reports R for "removed from surveillance", which is not the
+  # same as never having been listed.
+  validates :asm_gsm_flag, inclusion: { in: %w[Y N R] }, allow_nil: true
+  validates :featureable_id, uniqueness: { scope: :featureable_type }
+
+  scope :bracket_allowed, -> { where(bracket_flag: 'Y') }
+  scope :cover_allowed, -> { where(cover_flag: 'Y') }
+  # 'R' means the exchange lifted the restriction, so it is tradable.
+  scope :unrestricted, -> { where(asm_gsm_flag: [nil, 'N', 'R']) }
+
+  def bracket_order_allowed?
+    bracket_flag == 'Y'
+  end
+
+  def cover_order_allowed?
+    cover_flag == 'Y'
+  end
+
+  def surveillance_restricted?
+    asm_gsm_flag == 'Y'
+  end
 end

--- a/app/services/catalog/factor_score_engine.rb
+++ b/app/services/catalog/factor_score_engine.rb
@@ -35,7 +35,9 @@ module Catalog
 
     def load_instruments
       Rails.logger.debug '[INFO] Loading instruments from database'
-      @symbols = Instrument.where(exchange: 'NSE', segment: 'E', instrument: 'EQUITY')
+      # `instrument:` is not a column (the scrip master's INSTRUMENT lands in
+      # `instrument_code`), so this raised StatementInvalid on every run.
+      @symbols = Instrument.active.nse.segment_equity.instrument_code_equity
         .select(:security_id, :symbol_name)
         .distinct
         .limit(500)

--- a/app/services/instruments_import/deactivator.rb
+++ b/app/services/instruments_import/deactivator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module InstrumentsImport
+  # Retires rows the exchange has stopped listing.
+  #
+  # The importer only ever upserted, so every expired weekly option ever
+  # downloaded stayed in `derivatives` as a tradable-looking contract, and a
+  # delisted scrip still resolved to a security_id the gateway would happily
+  # send an order for.
+  #
+  # Rows are flagged, never deleted: orders, positions, exit logs and position
+  # trackers reference these instruments by security_id, and a delivery
+  # position can outlive the contract's listing. Deleting would break the audit
+  # trail for a position still open.
+  class Deactivator < ApplicationService
+    def initialize(started_at:)
+      @started_at = started_at
+    end
+
+    def call
+      # Anything not stamped by the run that just finished was absent from the
+      # feed. `last_seen_at IS NULL` covers rows that predate the column.
+      deactivated = [Instrument, Derivative].sum do |klass|
+        # rubocop:disable Rails/SkipsModelValidations -- a bulk flag flip over
+        # six-figure row counts; there is nothing to validate and instantiating
+        # each row would make the sweep unusable.
+        klass.active
+          .where(last_seen_at: ...@started_at)
+          .or(klass.active.where(last_seen_at: nil))
+          .update_all(active: false, updated_at: Time.current)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      # A row that reappears in a later feed is reactivated by the upsert,
+      # which writes `active: true` back.
+      { deactivated_rows: deactivated }
+    end
+  end
+end

--- a/app/services/instruments_import/parser.rb
+++ b/app/services/instruments_import/parser.rb
@@ -3,9 +3,53 @@
 require 'csv'
 
 module InstrumentsImport
-  # Parses the raw CSV content and builds normalized attribute hashes.
+  # Parses the detailed scrip master and splits each row into the tables that
+  # own its columns: identity and contract data onto `instruments` or
+  # `derivatives`, tradability flags onto `order_features`, CO/BO percentages
+  # onto `margin_requirements`.
+  #
+  # Satellite rows travel alongside their owner keyed by the owner's natural
+  # key, because the owner's primary key does not exist until the Upserter has
+  # run.
   class Parser < ApplicationService
     VALID_EXCHANGES = %w[NSE BSE MCX].freeze
+
+    # Detailed-CSV column => order_features column.
+    FEATURE_COLUMNS = {
+      'BRACKET_FLAG' => :bracket_flag,
+      'COVER_FLAG' => :cover_flag,
+      'BUY_SELL_INDICATOR' => :buy_sell_indicator,
+      'ASM_GSM_FLAG' => :asm_gsm_flag,
+      'ASM_GSM_CATEGORY' => :asm_gsm_category
+    }.freeze
+
+    # Detailed-CSV column => margin_requirements column. SELL_BO_SL_MIN_RANGE
+    # is the scrip master's own inconsistency — every sibling ends in _PERC.
+    MARGIN_COLUMNS = {
+      'BUY_CO_MIN_MARGIN_PER' => :buy_co_min_margin_per,
+      'SELL_CO_MIN_MARGIN_PER' => :sell_co_min_margin_per,
+      'BUY_CO_SL_RANGE_MAX_PERC' => :buy_co_sl_range_max_perc,
+      'SELL_CO_SL_RANGE_MAX_PERC' => :sell_co_sl_range_max_perc,
+      'BUY_CO_SL_RANGE_MIN_PERC' => :buy_co_sl_range_min_perc,
+      'SELL_CO_SL_RANGE_MIN_PERC' => :sell_co_sl_range_min_perc,
+      'BUY_BO_MIN_MARGIN_PER' => :buy_bo_min_margin_per,
+      'SELL_BO_MIN_MARGIN_PER' => :sell_bo_min_margin_per,
+      'BUY_BO_SL_RANGE_MAX_PERC' => :buy_bo_sl_range_max_perc,
+      'SELL_BO_SL_RANGE_MAX_PERC' => :sell_bo_sl_range_max_perc,
+      'BUY_BO_SL_RANGE_MIN_PERC' => :buy_bo_sl_range_min_perc,
+      'SELL_BO_SL_MIN_RANGE' => :sell_bo_sl_min_range,
+      'BUY_BO_PROFIT_RANGE_MAX_PERC' => :buy_bo_profit_range_max_perc,
+      'SELL_BO_PROFIT_RANGE_MAX_PERC' => :sell_bo_profit_range_max_perc,
+      'BUY_BO_PROFIT_RANGE_MIN_PERC' => :buy_bo_profit_range_min_perc,
+      'SELL_BO_PROFIT_RANGE_MIN_PERC' => :sell_bo_profit_range_min_perc
+    }.freeze
+
+    # The tuple the upserts conflict on. Satellites carry it so they can be
+    # attached to their owner once the owner has an id.
+    def self.natural_key(attrs)
+      [attrs[:security_id].to_s, attrs[:symbol_name].to_s,
+       attrs[:exchange].to_s, attrs[:segment].to_s]
+    end
 
     def initialize(csv_content)
       @csv_content = csv_content
@@ -14,31 +58,48 @@ module InstrumentsImport
     def call
       instruments = []
       derivatives = []
+      features = []
+      margins = []
 
-      CSV.parse(@csv_content, headers: true).each do |row|
+      # Streamed rather than CSV.parse'd: the detailed master is well over a
+      # hundred thousand rows and CSV.parse materialises every one as a
+      # CSV::Row before the first is looked at.
+      CSV.new(@csv_content, headers: true).each do |row|
         next unless VALID_EXCHANGES.include?(row['EXCH_ID'])
 
         attrs = build_attrs(row)
-        if row['SEGMENT'] == 'D'
-          dr = attrs.slice(*derivative_column_symbols)
-          dr[:asm_gsm_flag] = (row['ASM_GSM_FLAG'] == 'Y') if dr.key?(:asm_gsm_flag)
-          derivatives << dr
+        derivative = row['SEGMENT'] == 'D'
+        owner_type = derivative ? 'Derivative' : 'Instrument'
+        key = self.class.natural_key(attrs)
+
+        if derivative
+          derivatives << attrs.slice(*derivative_column_symbols)
         else
           instruments << attrs.slice(*instrument_column_symbols)
         end
+
+        if (feature = build_feature(row))
+          features << feature.merge(owner_type: owner_type, owner_key: key)
+        end
+        if (margin = build_margin(row))
+          margins << margin.merge(owner_type: owner_type, owner_key: key)
+        end
       end
 
-      { instruments: instruments, derivatives: derivatives }
+      { instruments: instruments, derivatives: derivatives,
+        order_features: features, margin_requirements: margins }
     end
 
     private
 
     def instrument_column_symbols
-      @instrument_column_symbols ||= (Instrument.column_names - ['id']).map(&:to_sym).freeze
+      # exchange_segment is a generated column — Postgres rejects any attempt
+      # to write it.
+      @instrument_column_symbols ||= (Instrument.column_names - %w[id exchange_segment]).map(&:to_sym).freeze
     end
 
     def derivative_column_symbols
-      @derivative_column_symbols ||= (Derivative.column_names - ['id']).map(&:to_sym).freeze
+      @derivative_column_symbols ||= (Derivative.column_names - %w[id exchange_segment]).map(&:to_sym).freeze
     end
 
     def build_attrs(row)
@@ -60,16 +121,39 @@ module InstrumentsImport
         series: row['SERIES'],
         lot_size: lot_size,
         tick_size: safe_float(row['TICK_SIZE']),
-        asm_gsm_flag: row['ASM_GSM_FLAG'],
-        asm_gsm_category: row['ASM_GSM_CATEGORY'],
-        mtf_leverage: safe_float(row['MTF_LEVERAGE']),
         expiry_date: safe_date(row['SM_EXPIRY_DATE']),
         strike_price: safe_float(row['STRIKE_PRICE']),
-        option_type: row['OPTION_TYPE'],
+        option_type: row['OPTION_TYPE'].presence,
         expiry_flag: row['EXPIRY_FLAG'],
+        # Present in this feed, so tradable and seen now. The staleness sweep
+        # flips `active` on whatever the feed stopped listing.
+        active: true,
+        last_seen_at: now,
         created_at: now,
         updated_at: now
       }
+    end
+
+    def build_feature(row)
+      attrs = FEATURE_COLUMNS.each_with_object({}) do |(csv_column, attribute), acc|
+        # Previously `asm_gsm_flag` was assigned `row['ASM_GSM_FLAG'] == 'Y'`
+        # for derivatives — a boolean into a string column, which Postgres
+        # stored as "true"/"false" and no Y/N comparison ever matched.
+        acc[attribute] = row[csv_column].to_s.strip.presence
+      end
+      attrs[:mtf_leverage] = safe_float(row['MTF_LEVERAGE'])
+      return nil if attrs.values.all?(&:nil?)
+
+      attrs
+    end
+
+    def build_margin(row)
+      attrs = MARGIN_COLUMNS.each_with_object({}) do |(csv_column, attribute), acc|
+        acc[attribute] = safe_float(row[csv_column])
+      end
+      return nil if attrs.values.all?(&:nil?)
+
+      attrs
     end
 
     def safe_date(str)

--- a/app/services/instruments_import/upserter.rb
+++ b/app/services/instruments_import/upserter.rb
@@ -1,23 +1,41 @@
 # frozen_string_literal: true
 
 module InstrumentsImport
-  # Handles the fast batch insertion/upserting of records into the database.
+  # Batch upserts one scrip-master parse into the four tables that own it.
+  #
+  # Every table conflicts on the same natural key the master itself is keyed by
+  # — (security_id, symbol_name, exchange, segment) — so re-running an import
+  # is idempotent.
   class Upserter < ApplicationService
     BATCH_SIZE = 1_000
 
-    def initialize(instruments_rows:, derivatives_rows:)
+    # `active` and `last_seen_at` are refreshed on every row the feed still
+    # lists, which is what lets the staleness sweep find the ones it does not.
+    SHARED_UPDATE_COLUMNS = %i[
+      display_name isin instrument_code instrument_type underlying_symbol
+      underlying_security_id series lot_size tick_size active last_seen_at updated_at
+    ].freeze
+
+    DERIVATIVE_UPDATE_COLUMNS = (SHARED_UPDATE_COLUMNS + %i[
+      expiry_date strike_price option_type expiry_flag instrument_id
+    ]).freeze
+
+    def initialize(instruments_rows:, derivatives_rows:, order_features_rows: [], margin_requirements_rows: [])
       @instruments_rows = instruments_rows
       @derivatives_rows = derivatives_rows
+      @order_features_rows = order_features_rows
+      @margin_requirements_rows = margin_requirements_rows
     end
 
     def call
       instrument_result = import_instruments!
       derivative_result = import_derivatives!
+      satellites = import_satellites!
 
       {
         instrument_upserts: instrument_result&.ids&.size.to_i,
         derivative_upserts: derivative_result&.ids&.size.to_i
-      }
+      }.merge(satellites)
     end
 
     private
@@ -30,8 +48,7 @@ module InstrumentsImport
         batch_size: BATCH_SIZE,
         on_duplicate_key_update: {
           conflict_target: %i[security_id symbol_name exchange segment],
-          columns: %i[display_name isin instrument_code instrument_type underlying_symbol series lot_size tick_size asm_gsm_flag
-                      asm_gsm_category mtf_leverage updated_at]
+          columns: SHARED_UPDATE_COLUMNS
         }
       )
     end
@@ -39,21 +56,101 @@ module InstrumentsImport
     def import_derivatives!
       return nil if @derivatives_rows.empty?
 
-      # Filter out derivatives with invalid instrument_ids just in case
-      valid_ids = Instrument.where(id: @derivatives_rows.filter_map { |r| r[:instrument_id] }.uniq).pluck(:id).to_set
-      validated = @derivatives_rows.select { |r| r[:instrument_id] && valid_ids.include?(r[:instrument_id]) }
-      return nil if validated.empty?
+      # instrument_id is nullable now, so a contract whose underlying is not in
+      # the master is stored unparented rather than discarded. Only ids that do
+      # not resolve are cleared, which keeps the FK honest without losing rows.
+      valid_ids = Instrument.where(id: @derivatives_rows.filter_map { |r| r[:instrument_id] }.uniq)
+        .pluck(:id).to_set
+      rows = @derivatives_rows.map do |row|
+        next row if row[:instrument_id].nil? || valid_ids.include?(row[:instrument_id])
+
+        row.merge(instrument_id: nil)
+      end
 
       Derivative.import(
-        validated,
+        rows,
         batch_size: BATCH_SIZE,
         on_duplicate_key_update: {
           conflict_target: %i[security_id symbol_name exchange segment],
-          columns: %i[display_name isin instrument_code instrument_type underlying_symbol
-                      underlying_security_id series expiry_date strike_price option_type lot_size
-                      expiry_flag tick_size asm_gsm_flag instrument_id updated_at]
+          columns: DERIVATIVE_UPDATE_COLUMNS
         }
       )
+    end
+
+    # Satellites arrive keyed by their owner's natural key; the owners only
+    # acquire ids in the two imports above, so resolve them here.
+    def import_satellites!
+      owner_ids = build_owner_id_index
+      {
+        order_feature_upserts: import_order_features!(owner_ids),
+        margin_requirement_upserts: import_margin_requirements!(owner_ids)
+      }
+    end
+
+    def build_owner_id_index
+      index = {}
+      { 'Instrument' => Instrument, 'Derivative' => Derivative }.each do |type, klass|
+        # `exchange` and `segment` are enums, so pluck yields the *keys*
+        # ("nse", "currency") while the parser keys satellites on the scrip
+        # master's own values ("NSE", "C"). Map back before comparing.
+        exchanges = klass.exchanges
+        segments = klass.segments
+
+        klass.pluck(:id, :security_id, :symbol_name, :exchange, :segment).each do |id, sid, name, exch, seg|
+          key = [sid.to_s, name.to_s,
+                 exchanges.fetch(exch.to_s, exch.to_s),
+                 segments.fetch(seg.to_s, seg.to_s)]
+          index[[type, key]] = id
+        end
+      end
+      index
+    end
+
+    def import_order_features!(owner_ids)
+      rows = resolve_owners(@order_features_rows, owner_ids, :featureable_type, :featureable_id)
+      return 0 if rows.empty?
+
+      OrderFeature.import(
+        rows,
+        batch_size: BATCH_SIZE,
+        validate: false,
+        on_duplicate_key_update: {
+          conflict_target: %i[featureable_type featureable_id],
+          columns: %i[bracket_flag cover_flag buy_sell_indicator asm_gsm_flag
+                      asm_gsm_category mtf_leverage updated_at]
+        }
+      ).ids.size
+    end
+
+    def import_margin_requirements!(owner_ids)
+      rows = resolve_owners(@margin_requirements_rows, owner_ids, :requirementable_type, :requirementable_id)
+      return 0 if rows.empty?
+
+      MarginRequirement.import(
+        rows,
+        batch_size: BATCH_SIZE,
+        validate: false,
+        on_duplicate_key_update: {
+          conflict_target: %i[requirementable_type requirementable_id],
+          columns: Parser::MARGIN_COLUMNS.values + %i[updated_at]
+        }
+      ).ids.size
+    end
+
+    def resolve_owners(rows, owner_ids, type_column, id_column)
+      now = Time.current
+      rows.filter_map do |row|
+        attrs = row.except(:owner_type, :owner_key)
+        owner_id = owner_ids[[row[:owner_type], row[:owner_key]]]
+        next if owner_id.nil?
+
+        attrs.merge(
+          type_column => row[:owner_type],
+          id_column => owner_id,
+          :created_at => now,
+          :updated_at => now
+        )
+      end
     end
   end
 end

--- a/app/services/instruments_importer.rb
+++ b/app/services/instruments_importer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-# Orchestrates the importing of Dhan API scrip master CSV into instruments and derivatives.
+# Orchestrates a scrip-master import: fetch, parse, link derivatives to their
+# underlying, upsert the four tables, retire whatever dropped out of the feed,
+# and record the run.
 class InstrumentsImporter < ApplicationService
   def self.import_from_url
     new.import_from_url
@@ -10,87 +12,91 @@ class InstrumentsImporter < ApplicationService
     new.import(file_path)
   end
 
-  def import_from_url
-    started_at = Time.current
-    csv_content = InstrumentsImport::Fetcher.call
-    summary = process_csv(csv_content)
-
-    summary[:started_at] = started_at
-    summary[:finished_at] = Time.current
-    summary[:duration] = summary[:finished_at] - started_at
-
-    record_success!(summary)
-    summary
-  end
-
-  def import(file_path = nil)
-    started_at = Time.current
-    csv_content = InstrumentsImport::Fetcher.call(file_path: file_path)
-    summary = process_csv(csv_content)
-
-    if file_path.nil?
-      summary[:finished_at] = Time.current
-      summary[:duration] = summary[:finished_at] - started_at
-      record_success!(summary)
-    end
-
-    summary
-  end
-
   def self.import_from_csv(csv_content)
     new.import_from_csv(csv_content)
   end
 
+  def import_from_url
+    run(source: 'url') { InstrumentsImport::Fetcher.call }
+  end
+
+  def import(file_path = nil)
+    source = file_path ? 'file' : 'url'
+    run(source: source) { InstrumentsImport::Fetcher.call(file_path: file_path) }
+  end
+
+  # Parses content the caller already has. Deliberately not tracked as a sync
+  # run and does not retire anything: the caller may be passing a fixture or a
+  # single segment, and treating a partial feed as authoritative would
+  # deactivate every instrument it happens to omit.
   def import_from_csv(csv_content)
-    process_csv(csv_content)
+    process_csv(csv_content, deactivate_missing: false)
   end
 
   private
 
-  def process_csv(csv_content)
-    parsed_data = InstrumentsImport::Parser.call(csv_content)
+  def run(source:)
+    started_at = Time.current
+    sync_run = InstrumentSyncRun.create!(source: source, status: 'running', started_at: started_at)
 
-    # First, import instruments to get IDs for mapping
-    # Note: Using Upserter here just for Instruments so we have them available in Mapper
+    summary = process_csv(yield, deactivate_missing: true, started_at: started_at)
+
+    sync_run.succeed!(**summary.slice(
+      :instrument_rows, :derivative_rows, :instrument_upserts,
+      :derivative_upserts, :unparented_derivatives, :deactivated_rows
+    ))
+
+    summary.merge(
+      started_at: started_at,
+      finished_at: sync_run.finished_at,
+      duration: sync_run.duration,
+      sync_run_id: sync_run.id
+    )
+  rescue StandardError => e
+    # A crashed import used to be indistinguishable from one that never ran:
+    # nothing was written until the very end.
+    sync_run&.fail!(e.message)
+    raise
+  end
+
+  def process_csv(csv_content, deactivate_missing:, started_at: Time.current)
+    parsed = InstrumentsImport::Parser.call(csv_content)
+
+    # Instruments first: derivatives are linked by the parent's primary key,
+    # which does not exist until its row does.
     InstrumentsImport::Upserter.call(
-      instruments_rows: parsed_data[:instruments],
+      instruments_rows: parsed[:instruments],
       derivatives_rows: []
     )
 
-    mapped_derivatives = InstrumentsImport::Mapper.call(parsed_data[:derivatives])
+    mapped = InstrumentsImport::Mapper.call(parsed[:derivatives])
 
-    # Then, import derivatives with the mapped IDs
-    upsert_results = InstrumentsImport::Upserter.call(
+    # Unparented contracts are imported too — instrument_id is nullable, and
+    # dropping them made BSE index options unresolvable.
+    upserts = InstrumentsImport::Upserter.call(
       instruments_rows: [],
-      derivatives_rows: mapped_derivatives[:with_parent]
+      derivatives_rows: mapped[:with_parent] + mapped[:without_parent],
+      order_features_rows: parsed[:order_features],
+      margin_requirements_rows: parsed[:margin_requirements]
     )
 
+    deactivated = if deactivate_missing
+                    InstrumentsImport::Deactivator.call(started_at: started_at)[:deactivated_rows]
+                  else
+                    0
+                  end
+
     {
-      instrument_rows: parsed_data[:instruments].size,
-      derivative_rows: parsed_data[:derivatives].size,
-      instrument_upserts: parsed_data[:instruments].size, # Assuming all were upserted
-      derivative_upserts: upsert_results[:derivative_upserts],
+      instrument_rows: parsed[:instruments].size,
+      derivative_rows: parsed[:derivatives].size,
+      instrument_upserts: parsed[:instruments].size,
+      derivative_upserts: upserts[:derivative_upserts],
+      order_feature_upserts: upserts[:order_feature_upserts],
+      margin_requirement_upserts: upserts[:margin_requirement_upserts],
+      unparented_derivatives: mapped[:without_parent].size,
+      deactivated_rows: deactivated,
       instrument_total: Instrument.count,
       derivative_total: Derivative.count
     }
-  end
-
-  def record_success!(summary)
-    return unless defined?(AppSetting) && AppSetting.respond_to?(:[]=)
-
-    write_setting('instruments.last_imported_at', summary[:finished_at]&.iso8601)
-    write_setting('instruments.last_import_duration_sec', summary[:duration]&.then { |d| d.to_f.round(2).to_s })
-    write_setting('instruments.last_instrument_rows', summary[:instrument_rows].to_s)
-    write_setting('instruments.last_derivative_rows', summary[:derivative_rows].to_s)
-    write_setting('instruments.last_instrument_upserts', summary[:instrument_upserts].to_s)
-    write_setting('instruments.last_derivative_upserts', summary[:derivative_upserts].to_s)
-    write_setting('instruments.instrument_total', summary[:instrument_total].to_s)
-    write_setting('instruments.derivative_total', summary[:derivative_total].to_s)
-  end
-
-  def write_setting(key, value)
-    return if value.blank?
-
-    AppSetting[key] = value
   end
 end

--- a/app/services/screeners/stocks_screener.rb
+++ b/app/services/screeners/stocks_screener.rb
@@ -99,8 +99,11 @@ module Screeners
     end
 
     def optionable?(inst)
-      # Cheap check: any option contract for same underlying
-      Derivative.exists?(underlying_symbol: inst.underlying_symbol, instrument: 'OPTSTK')
+      # Cheap check: any option contract for same underlying.
+      # There is no `instrument` column — the scrip master's INSTRUMENT field
+      # is stored in `instrument_code` — so this raised StatementInvalid and
+      # the rescue below turned every stock into "not optionable".
+      Derivative.active.exists?(underlying_symbol: inst.underlying_symbol, instrument_code: 'OPTSTK')
     rescue StandardError
       false
     end

--- a/app/services/watchlists/refresh_service.rb
+++ b/app/services/watchlists/refresh_service.rb
@@ -223,10 +223,13 @@ module Watchlists
     end
 
     def derivative_flags(inst)
-      # Cheap DB checks; index derivatives.instrument, derivatives.underlying_symbol for speed
+      # Cheap DB checks against index_derivatives_on_options_chain.
+      # The column is `instrument_code`, not `instrument`; querying the latter
+      # raised StatementInvalid and the rescue below reported no derivatives
+      # for every symbol.
       under = inst.underlying_symbol
-      has_opt = Derivative.exists?(underlying_symbol: under, instrument: 'OPTSTK')
-      has_fut = Derivative.exists?(underlying_symbol: under, instrument: 'FUTSTK')
+      has_opt = Derivative.active.exists?(underlying_symbol: under, instrument_code: 'OPTSTK')
+      has_fut = Derivative.active.exists?(underlying_symbol: under, instrument_code: 'FUTSTK')
 
       { has_derivatives: has_opt || has_fut, has_options: has_opt, has_futures: has_fut }
     rescue StandardError

--- a/db/migrate/20260727130000_create_instrument_sync_runs.rb
+++ b/db/migrate/20260727130000_create_instrument_sync_runs.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Audit trail for scrip-master imports.
+#
+# The importer previously scribbled eight loose strings into `app_settings`
+# ("instruments.last_imported_at", "instruments.last_derivative_rows", ...),
+# which keeps only the most recent run, stores numbers as text and cannot
+# record a failure at all — a crashed import looks exactly like one that never
+# ran. One row per run keeps the history and makes staleness a query.
+class CreateInstrumentSyncRuns < ActiveRecord::Migration[8.0]
+  def change
+    create_table :instrument_sync_runs do |t|
+      t.string :source, null: false, default: 'url'
+      t.string :status, null: false, default: 'running'
+      t.datetime :started_at, null: false
+      t.datetime :finished_at
+
+      t.integer :instrument_rows, null: false, default: 0
+      t.integer :derivative_rows, null: false, default: 0
+      t.integer :instrument_upserts, null: false, default: 0
+      t.integer :derivative_upserts, null: false, default: 0
+      t.integer :unparented_derivatives, null: false, default: 0
+      t.integer :deactivated_rows, null: false, default: 0
+
+      t.text :error_message
+
+      t.timestamps
+    end
+
+    add_index :instrument_sync_runs, :started_at
+    add_index :instrument_sync_runs, %i[status started_at]
+  end
+end

--- a/db/migrate/20260727130100_add_lifecycle_columns_to_instruments.rb
+++ b/db/migrate/20260727130100_add_lifecycle_columns_to_instruments.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Gives instruments and derivatives a lifecycle and a first-class exchange segment.
+#
+# Three gaps this closes:
+#
+# 1. Nothing ever retired a row. The importer only upserts, so every expired
+#    weekly option ever downloaded stays in `derivatives` forever, and a
+#    contract the exchange has delisted still resolves to a tradable
+#    security_id. `active` + `last_seen_at` let the importer mark rows that
+#    dropped out of the feed without deleting rows that orders/positions still
+#    reference by security_id.
+#
+# 2. `Repositories::InstrumentRepository.active_instruments` already queries
+#    `Instrument.where(active: true)` against a column that does not exist, so
+#    it raises on every call.
+#
+# 3. `exchange_segment` — the key every DhanHQ call and every WebSocket tick is
+#    addressed by — was computed in Ruby from (exchange, segment), so it could
+#    not be indexed or queried. As a stored generated column it is maintained
+#    by Postgres, so it cannot drift from its inputs, and
+#    `InstrumentHelpers#exchange_segment` already prefers `self[:exchange_segment]`
+#    when present and picks it up for free.
+class AddLifecycleColumnsToInstruments < ActiveRecord::Migration[8.0]
+  # Mirrors InstrumentHelpers#exchange_segment. IDX_I intentionally covers both
+  # NSE and BSE indices — that is DhanHQ's own segment, not a collapse on our side.
+  EXCHANGE_SEGMENT_SQL = <<~SQL.squish
+    CASE
+      WHEN segment = 'I' AND exchange IN ('NSE', 'BSE') THEN 'IDX_I'
+      WHEN segment = 'E' AND exchange = 'NSE' THEN 'NSE_EQ'
+      WHEN segment = 'E' AND exchange = 'BSE' THEN 'BSE_EQ'
+      WHEN segment = 'D' AND exchange = 'NSE' THEN 'NSE_FNO'
+      WHEN segment = 'D' AND exchange = 'BSE' THEN 'BSE_FNO'
+      WHEN segment = 'C' AND exchange = 'NSE' THEN 'NSE_CURRENCY'
+      WHEN segment = 'C' AND exchange = 'BSE' THEN 'BSE_CURRENCY'
+      WHEN segment = 'M' AND exchange = 'MCX' THEN 'MCX_COMM'
+    END
+  SQL
+
+  def change
+    %i[instruments derivatives].each do |table|
+      add_column table, :active, :boolean, null: false, default: true
+      add_column table, :last_seen_at, :datetime
+      add_column table, :exchange_segment, :virtual,
+                 type: :string, as: EXCHANGE_SEGMENT_SQL, stored: true
+    end
+
+    # Rows already in the table predate the feed, so treat them as seen at
+    # migration time rather than leaving them instantly stale.
+    reversible do |dir|
+      dir.up do
+        %w[instruments derivatives].each do |table|
+          execute("UPDATE #{table} SET last_seen_at = updated_at WHERE last_seen_at IS NULL")
+        end
+      end
+    end
+
+    # A contract is tradable whether or not we have matched its underlying.
+    # With NOT NULL, InstrumentsImport::Upserter silently dropped every
+    # derivative whose underlying instrument was missing from the master —
+    # BSE index options in particular — so they could never be resolved.
+    change_column_null :derivatives, :instrument_id, true
+  end
+end

--- a/db/migrate/20260727130200_backfill_instrument_trading_rules.rb
+++ b/db/migrate/20260727130200_backfill_instrument_trading_rules.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+# Moves the scrip master's trading-rule columns into the satellite tables that
+# already exist for them.
+#
+# `margin_requirements` and `order_features` were created in the original
+# schema as polymorphic satellites of Instrument/Derivative, and then never
+# written to: InstrumentsImport::Parser builds one flat hash and slices it by
+# `Instrument.column_names`, so all 24 rule columns were duplicated onto both
+# wide tables instead. The result is 24 columns × 2 tables that are almost
+# entirely NULL (the parser only ever filled asm_gsm_flag, asm_gsm_category and
+# mtf_leverage) sitting in the middle of the two hottest tables in the app.
+#
+# This backfills the satellites from whatever the wide columns hold today; the
+# next migration drops the duplicates.
+class BackfillInstrumentTradingRules < ActiveRecord::Migration[8.0]
+  # ASM/GSM surveillance status and MTF leverage are tradability facts, so they
+  # belong with the bracket/cover flags rather than with the margin percentages.
+  def change
+    add_column :order_features, :asm_gsm_flag, :string
+    add_column :order_features, :asm_gsm_category, :string
+    add_column :order_features, :mtf_leverage, :decimal, precision: 8, scale: 2
+
+    # Needed as an upsert conflict target, and a satellite is 1:1 with its
+    # owner by definition — the original index allowed duplicates.
+    reversible do |dir|
+      dir.up { deduplicate_order_features! }
+    end
+
+    remove_index :order_features, column: %i[featureable_type featureable_id],
+                                  name: 'index_order_features_on_featureable'
+    add_index :order_features, %i[featureable_type featureable_id],
+              unique: true, name: 'index_order_features_on_featureable'
+
+    reversible do |dir|
+      dir.up do
+        %w[Instrument Derivative].each do |owner|
+          backfill_order_features!(owner)
+          backfill_margin_requirements!(owner)
+        end
+      end
+    end
+  end
+
+  private
+
+  def table_for(owner)
+    owner == 'Instrument' ? 'instruments' : 'derivatives'
+  end
+
+  def deduplicate_order_features!
+    execute(<<~SQL.squish)
+      DELETE FROM order_features a
+      USING order_features b
+      WHERE a.featureable_type = b.featureable_type
+        AND a.featureable_id = b.featureable_id
+        AND a.id < b.id
+    SQL
+  end
+
+  def backfill_order_features!(owner)
+    table = table_for(owner)
+    # `derivatives.asm_gsm_flag` holds "true"/"false" on rows written by the
+    # pre-fix parser, which assigned a boolean into a string column. Normalise
+    # those back to the exchange's own Y/N while the data moves.
+    execute(<<~SQL.squish)
+      INSERT INTO order_features
+        (featureable_type, featureable_id, bracket_flag, cover_flag, buy_sell_indicator,
+         asm_gsm_flag, asm_gsm_category, mtf_leverage, created_at, updated_at)
+      SELECT '#{owner}', s.id, s.bracket_flag, s.cover_flag, s.buy_sell_indicator,
+             CASE s.asm_gsm_flag WHEN 'true' THEN 'Y' WHEN 'false' THEN 'N' ELSE s.asm_gsm_flag END,
+             s.asm_gsm_category, s.mtf_leverage, NOW(), NOW()
+      FROM #{table} s
+      WHERE COALESCE(s.bracket_flag, s.cover_flag, s.buy_sell_indicator,
+                     s.asm_gsm_flag, s.asm_gsm_category) IS NOT NULL
+         OR s.mtf_leverage IS NOT NULL
+      ON CONFLICT (featureable_type, featureable_id) DO UPDATE SET
+        bracket_flag = EXCLUDED.bracket_flag,
+        cover_flag = EXCLUDED.cover_flag,
+        buy_sell_indicator = EXCLUDED.buy_sell_indicator,
+        asm_gsm_flag = EXCLUDED.asm_gsm_flag,
+        asm_gsm_category = EXCLUDED.asm_gsm_category,
+        mtf_leverage = EXCLUDED.mtf_leverage,
+        updated_at = NOW()
+    SQL
+  end
+
+  MARGIN_COLUMNS = %w[
+    buy_co_min_margin_per sell_co_min_margin_per
+    buy_co_sl_range_max_perc sell_co_sl_range_max_perc
+    buy_co_sl_range_min_perc sell_co_sl_range_min_perc
+    buy_bo_min_margin_per sell_bo_min_margin_per
+    buy_bo_sl_range_max_perc sell_bo_sl_range_max_perc
+    buy_bo_sl_range_min_perc sell_bo_sl_min_range
+    buy_bo_profit_range_max_perc sell_bo_profit_range_max_perc
+    buy_bo_profit_range_min_perc sell_bo_profit_range_min_perc
+  ].freeze
+
+  def backfill_margin_requirements!(owner)
+    table = table_for(owner)
+    selected = MARGIN_COLUMNS.map { |c| "s.#{c}" }.join(', ')
+    assignments = MARGIN_COLUMNS.map { |c| "#{c} = EXCLUDED.#{c}" }.join(', ')
+
+    execute(<<~SQL.squish)
+      INSERT INTO margin_requirements
+        (requirementable_type, requirementable_id, #{MARGIN_COLUMNS.join(', ')}, created_at, updated_at)
+      SELECT '#{owner}', s.id, #{selected}, NOW(), NOW()
+      FROM #{table} s
+      WHERE COALESCE(#{selected}) IS NOT NULL
+      ON CONFLICT (requirementable_type, requirementable_id) DO UPDATE SET
+        #{assignments}, updated_at = NOW()
+    SQL
+  end
+end

--- a/db/migrate/20260727130300_drop_duplicated_trading_rule_columns.rb
+++ b/db/migrate/20260727130300_drop_duplicated_trading_rule_columns.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Drops the 22 trading-rule columns now owned by `order_features` and
+# `margin_requirements` (see the preceding backfill migration) from both wide
+# tables.
+#
+# These were dead weight on the two tables every tick, every order and every
+# option-chain read touches: the importer never wrote 16 of the 22, and the
+# other six now live in the satellites that were built for them.
+class DropDuplicatedTradingRuleColumns < ActiveRecord::Migration[8.0]
+  FLAG_COLUMNS = {
+    bracket_flag: :string,
+    cover_flag: :string,
+    asm_gsm_flag: :string,
+    asm_gsm_category: :string,
+    buy_sell_indicator: :string
+  }.freeze
+
+  MARGIN_COLUMNS = %i[
+    buy_co_min_margin_per sell_co_min_margin_per
+    buy_co_sl_range_max_perc sell_co_sl_range_max_perc
+    buy_co_sl_range_min_perc sell_co_sl_range_min_perc
+    buy_bo_min_margin_per sell_bo_min_margin_per
+    buy_bo_sl_range_max_perc sell_bo_sl_range_max_perc
+    buy_bo_sl_range_min_perc sell_bo_sl_min_range
+    buy_bo_profit_range_max_perc sell_bo_profit_range_max_perc
+    buy_bo_profit_range_min_perc sell_bo_profit_range_min_perc
+    mtf_leverage
+  ].freeze
+
+  def change
+    %i[instruments derivatives].each do |table|
+      FLAG_COLUMNS.each { |column, type| remove_column table, column, type }
+      MARGIN_COLUMNS.each do |column|
+        remove_column table, column, :decimal, precision: 8, scale: 2
+      end
+    end
+  end
+end

--- a/db/migrate/20260727130400_add_instrument_lookup_indexes.rb
+++ b/db/migrate/20260727130400_add_instrument_lookup_indexes.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Indexes for the three lookups this app actually performs at runtime.
+#
+# Before this, `derivatives` had exactly one useful index for reads —
+# (underlying_symbol, expiry_date) — and every strike/option_type filter on top
+# of it was a heap scan over the whole expiry. Tick mapping
+# (Dhan::WS::FeedListener, Orders::Manager, Paper::Positions) looked rows up by
+# security_id alone, which could only use the leading column of the
+# (security_id, symbol_name, exchange, segment) unique index and matched across
+# every segment.
+class AddInstrumentLookupIndexes < ActiveRecord::Migration[8.0]
+  def change
+    # 1. Tick/order → row. The WebSocket addresses instruments as
+    #    (exchange_segment, security_id) and so does every DhanHQ order payload.
+    #    Deliberately not unique: DhanHQ folds NSE and BSE indices into a single
+    #    IDX_I segment, so uniqueness here is not ours to assert.
+    add_index :instruments, %i[exchange_segment security_id],
+              name: 'index_instruments_on_segment_and_security_id'
+    add_index :derivatives, %i[exchange_segment security_id],
+              name: 'index_derivatives_on_segment_and_security_id'
+
+    # 2. Option chain. Trading::DerivativeResolver, AlertProcessors::Index and
+    #    Option::* all filter on exactly this tuple. Partial on `active` so
+    #    retired contracts do not bloat the index that sizes every entry.
+    #
+    #    Column order matches Derivative.options_chain's ORDER BY
+    #    (strike_price, option_type), so the index can return the chain already
+    #    sorted. Putting option_type before strike_price — the obvious reading
+    #    of "filter by CE/PE, then strike" — cannot, because a chain wants both
+    #    sides interleaved by strike rather than one side after the other.
+    #
+    #    Measured on 120k contracts: resolving a single strike before an order
+    #    (underlying + expiry + strike + option_type, the DerivativeResolver
+    #    path) is an index-only condition on all four columns at ~0.07ms, and a
+    #    strike window around spot scans the index for the range. For a whole
+    #    expiry the planner may still prefer a bitmap scan plus a sort; that is
+    #    a costing decision, not a missing capability.
+    add_index :derivatives,
+              %i[underlying_symbol expiry_date strike_price option_type],
+              name: 'index_derivatives_on_options_chain',
+              where: 'active AND underlying_symbol IS NOT NULL'
+
+    # 3. Expiry discovery for a known underlying (expiry_list, rollover checks).
+    add_index :derivatives, %i[instrument_id expiry_date],
+              name: 'index_derivatives_on_instrument_and_expiry',
+              where: 'instrument_id IS NOT NULL'
+
+    # 4. Universe scans: Screeners::StocksScreener and Catalog::FactorScoreEngine
+    #    both walk (exchange, segment, instrument_code).
+    add_index :instruments, %i[segment instrument_code active],
+              name: 'index_instruments_on_segment_and_code'
+
+    # 5. Staleness sweeps by the importer.
+    add_index :instruments, :last_seen_at
+    add_index :derivatives, :last_seen_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_27_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_27_130400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -63,7 +63,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_27_120000) do
   end
 
   create_table "derivatives", force: :cascade do |t|
-    t.bigint "instrument_id", null: false
+    t.bigint "instrument_id"
     t.string "exchange"
     t.string "segment"
     t.string "security_id"
@@ -81,33 +81,18 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_27_120000) do
     t.string "option_type"
     t.decimal "tick_size", precision: 10, scale: 4
     t.string "expiry_flag"
-    t.string "bracket_flag"
-    t.string "cover_flag"
-    t.string "asm_gsm_flag"
-    t.string "asm_gsm_category"
-    t.string "buy_sell_indicator"
-    t.decimal "buy_co_min_margin_per", precision: 8, scale: 2
-    t.decimal "sell_co_min_margin_per", precision: 8, scale: 2
-    t.decimal "buy_co_sl_range_max_perc", precision: 8, scale: 2
-    t.decimal "sell_co_sl_range_max_perc", precision: 8, scale: 2
-    t.decimal "buy_co_sl_range_min_perc", precision: 8, scale: 2
-    t.decimal "sell_co_sl_range_min_perc", precision: 8, scale: 2
-    t.decimal "buy_bo_min_margin_per", precision: 8, scale: 2
-    t.decimal "sell_bo_min_margin_per", precision: 8, scale: 2
-    t.decimal "buy_bo_sl_range_max_perc", precision: 8, scale: 2
-    t.decimal "sell_bo_sl_range_max_perc", precision: 8, scale: 2
-    t.decimal "buy_bo_sl_range_min_perc", precision: 8, scale: 2
-    t.decimal "sell_bo_sl_min_range", precision: 8, scale: 2
-    t.decimal "buy_bo_profit_range_max_perc", precision: 8, scale: 2
-    t.decimal "sell_bo_profit_range_max_perc", precision: 8, scale: 2
-    t.decimal "buy_bo_profit_range_min_perc", precision: 8, scale: 2
-    t.decimal "sell_bo_profit_range_min_perc", precision: 8, scale: 2
-    t.decimal "mtf_leverage", precision: 8, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true, null: false
+    t.datetime "last_seen_at"
+    t.virtual "exchange_segment", type: :string, as: "\nCASE\n    WHEN (((segment)::text = 'I'::text) AND ((exchange)::text = ANY (ARRAY[('NSE'::character varying)::text, ('BSE'::character varying)::text]))) THEN 'IDX_I'::text\n    WHEN (((segment)::text = 'E'::text) AND ((exchange)::text = 'NSE'::text)) THEN 'NSE_EQ'::text\n    WHEN (((segment)::text = 'E'::text) AND ((exchange)::text = 'BSE'::text)) THEN 'BSE_EQ'::text\n    WHEN (((segment)::text = 'D'::text) AND ((exchange)::text = 'NSE'::text)) THEN 'NSE_FNO'::text\n    WHEN (((segment)::text = 'D'::text) AND ((exchange)::text = 'BSE'::text)) THEN 'BSE_FNO'::text\n    WHEN (((segment)::text = 'C'::text) AND ((exchange)::text = 'NSE'::text)) THEN 'NSE_CURRENCY'::text\n    WHEN (((segment)::text = 'C'::text) AND ((exchange)::text = 'BSE'::text)) THEN 'BSE_CURRENCY'::text\n    WHEN (((segment)::text = 'M'::text) AND ((exchange)::text = 'MCX'::text)) THEN 'MCX_COMM'::text\n    ELSE NULL::text\nEND", stored: true
+    t.index ["exchange_segment", "security_id"], name: "index_derivatives_on_segment_and_security_id"
+    t.index ["instrument_id", "expiry_date"], name: "index_derivatives_on_instrument_and_expiry", where: "(instrument_id IS NOT NULL)"
     t.index ["instrument_id"], name: "index_derivatives_on_instrument_id"
+    t.index ["last_seen_at"], name: "index_derivatives_on_last_seen_at"
     t.index ["security_id", "symbol_name", "exchange", "segment"], name: "index_derivatives_unique", unique: true
     t.index ["symbol_name"], name: "index_derivatives_on_symbol_name"
+    t.index ["underlying_symbol", "expiry_date", "strike_price", "option_type"], name: "index_derivatives_on_options_chain", where: "(active AND (underlying_symbol IS NOT NULL))"
     t.index ["underlying_symbol", "expiry_date"], name: "index_derivatives_on_underlying_symbol_and_expiry_date", where: "(underlying_symbol IS NOT NULL)"
   end
 
@@ -145,6 +130,24 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_27_120000) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "instrument_sync_runs", force: :cascade do |t|
+    t.string "source", default: "url", null: false
+    t.string "status", default: "running", null: false
+    t.datetime "started_at", null: false
+    t.datetime "finished_at"
+    t.integer "instrument_rows", default: 0, null: false
+    t.integer "derivative_rows", default: 0, null: false
+    t.integer "instrument_upserts", default: 0, null: false
+    t.integer "derivative_upserts", default: 0, null: false
+    t.integer "unparented_derivatives", default: 0, null: false
+    t.integer "deactivated_rows", default: 0, null: false
+    t.text "error_message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["started_at"], name: "index_instrument_sync_runs_on_started_at"
+    t.index ["status", "started_at"], name: "index_instrument_sync_runs_on_status_and_started_at"
+  end
+
   create_table "instruments", force: :cascade do |t|
     t.string "exchange", null: false
     t.string "segment", null: false
@@ -163,32 +166,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_27_120000) do
     t.string "option_type"
     t.decimal "tick_size"
     t.string "expiry_flag"
-    t.string "bracket_flag"
-    t.string "cover_flag"
-    t.string "asm_gsm_flag"
-    t.string "asm_gsm_category"
-    t.string "buy_sell_indicator"
-    t.decimal "buy_co_min_margin_per", precision: 8, scale: 2
-    t.decimal "sell_co_min_margin_per", precision: 8, scale: 2
-    t.decimal "buy_co_sl_range_max_perc", precision: 8, scale: 2
-    t.decimal "sell_co_sl_range_max_perc", precision: 8, scale: 2
-    t.decimal "buy_co_sl_range_min_perc", precision: 8, scale: 2
-    t.decimal "sell_co_sl_range_min_perc", precision: 8, scale: 2
-    t.decimal "buy_bo_min_margin_per", precision: 8, scale: 2
-    t.decimal "sell_bo_min_margin_per", precision: 8, scale: 2
-    t.decimal "buy_bo_sl_range_max_perc", precision: 8, scale: 2
-    t.decimal "sell_bo_sl_range_max_perc", precision: 8, scale: 2
-    t.decimal "buy_bo_sl_range_min_perc", precision: 8, scale: 2
-    t.decimal "sell_bo_sl_min_range", precision: 8, scale: 2
-    t.decimal "buy_bo_profit_range_max_perc", precision: 8, scale: 2
-    t.decimal "sell_bo_profit_range_max_perc", precision: 8, scale: 2
-    t.decimal "buy_bo_profit_range_min_perc", precision: 8, scale: 2
-    t.decimal "sell_bo_profit_range_min_perc", precision: 8, scale: 2
-    t.decimal "mtf_leverage", precision: 8, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true, null: false
+    t.datetime "last_seen_at"
+    t.virtual "exchange_segment", type: :string, as: "\nCASE\n    WHEN (((segment)::text = 'I'::text) AND ((exchange)::text = ANY (ARRAY[('NSE'::character varying)::text, ('BSE'::character varying)::text]))) THEN 'IDX_I'::text\n    WHEN (((segment)::text = 'E'::text) AND ((exchange)::text = 'NSE'::text)) THEN 'NSE_EQ'::text\n    WHEN (((segment)::text = 'E'::text) AND ((exchange)::text = 'BSE'::text)) THEN 'BSE_EQ'::text\n    WHEN (((segment)::text = 'D'::text) AND ((exchange)::text = 'NSE'::text)) THEN 'NSE_FNO'::text\n    WHEN (((segment)::text = 'D'::text) AND ((exchange)::text = 'BSE'::text)) THEN 'BSE_FNO'::text\n    WHEN (((segment)::text = 'C'::text) AND ((exchange)::text = 'NSE'::text)) THEN 'NSE_CURRENCY'::text\n    WHEN (((segment)::text = 'C'::text) AND ((exchange)::text = 'BSE'::text)) THEN 'BSE_CURRENCY'::text\n    WHEN (((segment)::text = 'M'::text) AND ((exchange)::text = 'MCX'::text)) THEN 'MCX_COMM'::text\n    ELSE NULL::text\nEND", stored: true
+    t.index ["exchange_segment", "security_id"], name: "index_instruments_on_segment_and_security_id"
     t.index ["instrument_code"], name: "index_instruments_on_instrument_code"
+    t.index ["last_seen_at"], name: "index_instruments_on_last_seen_at"
     t.index ["security_id", "symbol_name", "exchange", "segment"], name: "index_instruments_unique", unique: true
+    t.index ["segment", "instrument_code", "active"], name: "index_instruments_on_segment_and_code"
     t.index ["symbol_name"], name: "index_instruments_on_symbol_name"
     t.index ["underlying_symbol", "expiry_date"], name: "index_instruments_on_underlying_symbol_and_expiry_date", where: "(underlying_symbol IS NOT NULL)"
   end
@@ -276,7 +263,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_27_120000) do
     t.string "buy_sell_indicator"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["featureable_type", "featureable_id"], name: "index_order_features_on_featureable"
+    t.string "asm_gsm_flag"
+    t.string "asm_gsm_category"
+    t.decimal "mtf_leverage", precision: 8, scale: 2
+    t.index ["featureable_type", "featureable_id"], name: "index_order_features_on_featureable", unique: true
   end
 
   create_table "orders", force: :cascade do |t|

--- a/lib/tasks/instruments.rake
+++ b/lib/tasks/instruments.rake
@@ -103,36 +103,39 @@ namespace :instruments do
 
   desc 'Check instrument inventory freshness and counts'
   task status: :environment do
-    last_import_raw = Setting.fetch('instruments.last_imported_at')
+    # Reads instrument_sync_runs. This previously read a `Setting` constant
+    # that does not exist in this app (the model is AppSetting) and compared
+    # against InstrumentsImporter::CACHE_MAX_AGE, which lives on
+    # InstrumentsImport::Fetcher — so the task raised NameError either way.
+    run = InstrumentSyncRun.last_success
 
-    unless last_import_raw
-      pp 'No instrument import recorded yet.'
+    unless run
+      pp 'No successful instrument import recorded yet.'
+      failed = InstrumentSyncRun.status_failed.recent.first
+      pp "Last failure at #{failed.started_at}: #{failed.error_message}" if failed
       exit 1
     end
 
-    imported_at = Time.zone.parse(last_import_raw.to_s)
-    age_seconds = Time.current - imported_at
-    max_age     = InstrumentsImporter::CACHE_MAX_AGE
+    age_seconds = Time.current - run.finished_at
 
-    pp "Last import at: #{imported_at}"
+    pp "Last import at: #{run.finished_at}"
     pp "Age (seconds): #{age_seconds.round(2)}"
-    pp "Import duration (sec): #{Setting.fetch('instruments.last_import_duration_sec', 'unknown')}"
-    pp "Last instrument rows: #{Setting.fetch('instruments.last_instrument_rows', '0')}"
-    pp "Last derivative rows: #{Setting.fetch('instruments.last_derivative_rows', '0')}"
-    pp "Upserts (instruments): #{Setting.fetch('instruments.last_instrument_upserts', '0')}"
-    pp "Upserts (derivatives): #{Setting.fetch('instruments.last_derivative_upserts', '0')}"
-    pp "Total instruments: #{Setting.fetch('instruments.instrument_total', '0')}"
-    pp "Total derivatives: #{Setting.fetch('instruments.derivative_total', '0')}"
+    pp "Import duration (sec): #{run.duration&.round(2)}"
+    pp "Last instrument rows: #{run.instrument_rows}"
+    pp "Last derivative rows: #{run.derivative_rows}"
+    pp "Upserts (instruments): #{run.instrument_upserts}"
+    pp "Upserts (derivatives): #{run.derivative_upserts}"
+    pp "Unparented derivatives: #{run.unparented_derivatives}"
+    pp "Deactivated rows: #{run.deactivated_rows}"
+    pp "Total instruments: #{Instrument.count} (#{Instrument.active.count} active)"
+    pp "Total derivatives: #{Derivative.count} (#{Derivative.active.count} active)"
 
-    if age_seconds > max_age
-      pp "Status: STALE (older than #{max_age.inspect})"
+    if InstrumentSyncRun.stale?
+      pp "Status: STALE (older than #{InstrumentSyncRun::STALE_AFTER.inspect})"
       exit 1
     end
 
     pp 'Status: OK'
-  rescue ArgumentError => e
-    pp "Failed to parse last import timestamp: #{e.message}"
-    exit 1
   end
 end
 

--- a/spec/factories/derivatives.rb
+++ b/spec/factories/derivatives.rb
@@ -2,10 +2,45 @@
 
 FactoryBot.define do
   factory :derivative do
-    instrument
+    # Unparented by default: instrument_id is optional, the option-chain path
+    # matches on `underlying_symbol`, and auto-creating one Instrument per
+    # contract would collide on the instrument factory's fixed security_id.
+    instrument { nil }
+    sequence(:security_id) { |n| (40_000 + n).to_s }
+    sequence(:symbol_name) { |n| "NIFTY-#{n}-CE" }
+    exchange { 'nse' }
+    segment { 'derivatives' }
+    instrument_code { 'options_index' }
+    underlying_symbol { 'NIFTY' }
     strike_price { 2500.0 }
     option_type { 'CE' }
     expiry_date { Time.zone.today + 7.days }
-    expiry_flag { 'weekly' }
+    expiry_flag { 'W' }
+    lot_size { 75 }
+    tick_size { 0.05 }
+    active { true }
+    last_seen_at { Time.current }
+
+    trait :with_underlying do
+      instrument factory: %i[instrument nifty]
+    end
+
+    trait :put do
+      option_type { 'PE' }
+      sequence(:symbol_name) { |n| "NIFTY-#{n}-PE" }
+    end
+
+    # Futures carry no strike or CE/PE type.
+    trait :future do
+      instrument_code { 'futures_index' }
+      option_type { nil }
+      strike_price { nil }
+      sequence(:symbol_name) { |n| "NIFTY-#{n}-FUT" }
+    end
+
+    trait :expired do
+      expiry_date { Time.zone.today - 7.days }
+      active { false }
+    end
   end
 end

--- a/spec/factories/instruments.rb
+++ b/spec/factories/instruments.rb
@@ -13,9 +13,6 @@ FactoryBot.define do
     series { 'EQ' }
     lot_size { 1 }
     tick_size { 0.5 }
-    asm_gsm_flag { 'N' }
-    asm_gsm_category { 'NA' }
-    mtf_leverage { 3.77 }
     exchange { 'nse' }
     segment { 'equity' }
 
@@ -36,9 +33,6 @@ FactoryBot.define do
       series { 'X' }
       lot_size { 1 }
       tick_size { 0.1 }
-      asm_gsm_flag { 'N' }
-      asm_gsm_category { 'NA' }
-      mtf_leverage { 0.0 }
       exchange { 'nse' }
       segment { 'index' }
     end
@@ -54,9 +48,6 @@ FactoryBot.define do
       series { 'X' }
       lot_size { 1 }
       tick_size { 0.1 }
-      asm_gsm_flag { 'N' }
-      asm_gsm_category { 'NA' }
-      mtf_leverage { 0.0 }
       exchange { 'nse' }
       segment { 'index' }
     end
@@ -72,9 +63,6 @@ FactoryBot.define do
       series { 'NA' }
       lot_size { 75 }
       tick_size { 0.5 }
-      asm_gsm_flag { 'N' }
-      asm_gsm_category { 'NA' }
-      mtf_leverage { 0.0 }
       exchange { 'nse' }
       segment { 'derivatives' }
     end
@@ -90,9 +78,6 @@ FactoryBot.define do
       series { 'NA' }
       lot_size { 75 }
       tick_size { 0.5 }
-      asm_gsm_flag { 'N' }
-      asm_gsm_category { 'NA' }
-      mtf_leverage { 0.0 }
       exchange { 'nse' }
       segment { 'derivatives' }
     end

--- a/spec/factories/margin_requirements.rb
+++ b/spec/factories/margin_requirements.rb
@@ -2,7 +2,8 @@
 
 FactoryBot.define do
   factory :margin_requirement do
-    instrument
+    # Polymorphic owner (`requirementable`) — `instrument` is not an attribute.
+    requirementable factory: :instrument
     buy_co_min_margin_per { 20.0 }
     sell_co_min_margin_per { 20.0 }
     buy_bo_min_margin_per { 10.0 }

--- a/spec/factories/order_features.rb
+++ b/spec/factories/order_features.rb
@@ -2,9 +2,19 @@
 
 FactoryBot.define do
   factory :order_feature do
-    instrument
+    # The association is polymorphic (`featureable`); `instrument` is not an
+    # attribute on this model.
+    featureable factory: :instrument
     bracket_flag { 'Y' }
     cover_flag { 'Y' }
-    buy_sell_indicator { 'BOTH' }
+    buy_sell_indicator { 'A' }
+    asm_gsm_flag { 'N' }
+    asm_gsm_category { 'NA' }
+    mtf_leverage { 3.77 }
+
+    trait :restricted do
+      asm_gsm_flag { 'Y' }
+      asm_gsm_category { 'ASM_ST_I' }
+    end
   end
 end

--- a/spec/models/derivative_spec.rb
+++ b/spec/models/derivative_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Derivative do
+  describe 'validations' do
+    it 'accepts an option carrying a strike and a CE/PE type' do
+      expect(build(:derivative)).to be_valid
+    end
+
+    it 'accepts a future, which has neither strike nor option type' do
+      expect(build(:derivative, :future)).to be_valid
+    end
+
+    it 'rejects an option missing its strike' do
+      derivative = build(:derivative, strike_price: nil)
+
+      expect(derivative).not_to be_valid
+      expect(derivative.errors[:strike_price]).to be_present
+    end
+
+    it 'rejects an option type the exchange does not issue' do
+      expect(build(:derivative, option_type: 'XX')).not_to be_valid
+    end
+  end
+
+  describe 'underlying link' do
+    it 'stores a contract whose underlying is not in the instrument master' do
+      expect(build(:derivative, instrument: nil)).to be_valid
+    end
+
+    it 'links to its underlying when one was matched' do
+      contract = create(:derivative, :with_underlying)
+
+      expect(contract.instrument.symbol_name).to eq('NIFTY')
+    end
+  end
+
+  describe '.options_chain' do
+    let(:expiry) { Time.zone.today + 7.days }
+
+    before do
+      create(:derivative, underlying_symbol: 'NIFTY', expiry_date: expiry, strike_price: 22_600, option_type: 'CE')
+      create(:derivative, underlying_symbol: 'NIFTY', expiry_date: expiry, strike_price: 22_400, option_type: 'CE')
+      create(:derivative, underlying_symbol: 'NIFTY', expiry_date: expiry, strike_price: 22_400, option_type: 'PE')
+    end
+
+    it 'returns both sides of the chain ordered by strike' do
+      chain = described_class.options_chain('NIFTY', expiry)
+
+      expect(chain.map { |d| [d.strike_price.to_i, d.option_type] })
+        .to eq([[22_400, 'CE'], [22_400, 'PE'], [22_600, 'CE']])
+    end
+
+    it 'upcases the underlying so a lowercase caller still matches' do
+      expect(described_class.options_chain('nifty', expiry).count).to eq(3)
+    end
+
+    it 'excludes a different expiry' do
+      create(:derivative, underlying_symbol: 'NIFTY', expiry_date: expiry + 7.days, strike_price: 22_400,
+                          option_type: 'CE')
+
+      expect(described_class.options_chain('NIFTY', expiry).count).to eq(3)
+    end
+
+    it 'excludes retired contracts' do
+      described_class.where(strike_price: 22_600).update_all(active: false) # rubocop:disable Rails/SkipsModelValidations
+
+      expect(described_class.options_chain('NIFTY', expiry).count).to eq(2)
+    end
+
+    it 'excludes futures, which have no strike to sit on the chain' do
+      create(:derivative, :future, underlying_symbol: 'NIFTY', expiry_date: expiry)
+
+      expect(described_class.options_chain('NIFTY', expiry).count).to eq(3)
+    end
+  end
+
+  describe '.for_tick' do
+    it 'finds the contract the WebSocket addressed' do
+      contract = create(:derivative, exchange: 'nse', segment: 'derivatives', security_id: '44444')
+
+      expect(described_class.for_tick(exchange_segment: 'NSE_FNO', security_id: 44_444)).to eq(contract)
+    end
+
+    it 'does not cross segments' do
+      create(:derivative, exchange: 'nse', segment: 'derivatives', security_id: '44444')
+
+      expect(described_class.for_tick(exchange_segment: 'BSE_FNO', security_id: '44444')).to be_nil
+    end
+  end
+
+  describe '.expiries_for' do
+    it 'lists unexpired expiries nearest first, without duplicates' do
+      near = Time.zone.today + 3.days
+      far  = Time.zone.today + 10.days
+      create(:derivative, underlying_symbol: 'NIFTY', expiry_date: far)
+      create(:derivative, underlying_symbol: 'NIFTY', expiry_date: near)
+      create(:derivative, underlying_symbol: 'NIFTY', expiry_date: near, option_type: 'PE')
+      create(:derivative, :expired, underlying_symbol: 'NIFTY')
+
+      expect(described_class.expiries_for('NIFTY')).to eq([near, far])
+    end
+  end
+
+  describe '#exchange_segment' do
+    it 'reads the column Postgres generates from exchange and segment' do
+      contract = create(:derivative, exchange: 'bse', segment: 'derivatives')
+
+      expect(contract.exchange_segment).to eq('BSE_FNO')
+    end
+  end
+end

--- a/spec/models/instrument_sync_run_spec.rb
+++ b/spec/models/instrument_sync_run_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InstrumentSyncRun do
+  def succeeded_at(time, **counts)
+    described_class.create!(source: 'url', status: 'succeeded', started_at: time,
+                            finished_at: time, **counts)
+  end
+
+  describe '.stale?' do
+    it 'is stale when no import has ever succeeded' do
+      expect(described_class).to be_stale
+    end
+
+    it 'is stale when the only success predates the window' do
+      succeeded_at(described_class::STALE_AFTER.ago - 1.hour)
+
+      expect(described_class).to be_stale
+    end
+
+    it 'is fresh after a recent success' do
+      succeeded_at(1.hour.ago)
+
+      expect(described_class).not_to be_stale
+    end
+
+    it 'ignores a failure newer than the last success' do
+      succeeded_at(1.hour.ago)
+      described_class.create!(source: 'url', status: 'failed', started_at: Time.current,
+                              finished_at: Time.current, error_message: 'boom')
+
+      expect(described_class).not_to be_stale
+      expect(described_class.last_success.status).to eq('succeeded')
+    end
+
+    it 'is stale while a run is still in flight' do
+      described_class.create!(source: 'url', status: 'running', started_at: Time.current)
+
+      expect(described_class).to be_stale
+    end
+  end
+
+  describe '#succeed!' do
+    it 'records the counts and stamps the finish' do
+      run = described_class.create!(source: 'url', status: 'running', started_at: 2.minutes.ago)
+
+      run.succeed!(instrument_rows: 10, derivative_rows: 20, deactivated_rows: 3)
+
+      expect(run).to have_attributes(status: 'succeeded', instrument_rows: 10,
+                                     derivative_rows: 20, deactivated_rows: 3)
+      expect(run.duration).to be > 0
+    end
+  end
+
+  describe '#fail!' do
+    it 'keeps the reason so a crashed import is distinguishable from one that never ran' do
+      run = described_class.create!(source: 'url', status: 'running', started_at: Time.current)
+
+      run.fail!('connection reset')
+
+      expect(run).to have_attributes(status: 'failed', error_message: 'connection reset')
+      expect(run.finished_at).to be_present
+    end
+  end
+end

--- a/spec/services/csv_importer_spec.rb
+++ b/spec/services/csv_importer_spec.rb
@@ -23,6 +23,56 @@ RSpec.describe InstrumentsImporter, type: :service do
         expect(summary).to include(:instrument_rows, :derivative_rows, :instrument_upserts, :derivative_upserts, :instrument_total,
                                    :derivative_total)
       end
+
+      it 'writes the trading rules to the satellite tables, not the wide table' do
+        described_class.import(mock_csv_path)
+        instrument = Instrument.find_by(security_id: '2885', segment: 'equity')
+
+        expect(instrument.order_feature).to have_attributes(
+          bracket_flag: 'Y', cover_flag: 'Y', buy_sell_indicator: 'A', asm_gsm_flag: 'N'
+        )
+        expect(instrument.margin_requirement.buy_co_min_margin_per).to eq(20.0)
+      end
+
+      it 'attaches satellites to derivatives as well as instruments' do
+        described_class.import(mock_csv_path)
+        contract = Derivative.find_by(security_id: '35024')
+
+        # The old parser wrote "true"/"false" here via a boolean assigned into
+        # a string column, so no Y/N comparison ever matched.
+        expect(contract.order_feature.asm_gsm_flag).to be_in(%w[Y N R])
+      end
+
+      it 'stamps every imported row as active and seen' do
+        described_class.import(mock_csv_path)
+
+        expect(Instrument.where(active: false)).to be_empty
+        expect(Instrument.where(last_seen_at: nil)).to be_empty
+      end
+
+      it 'records the run instead of scribbling strings into app_settings' do
+        expect { described_class.import(mock_csv_path) }.to change(InstrumentSyncRun, :count).by(1)
+
+        run = InstrumentSyncRun.last_success
+        expect(run).to have_attributes(source: 'file', status: 'succeeded')
+        expect(run.instrument_rows).to be_positive
+        expect(InstrumentSyncRun).not_to be_stale
+      end
+
+      it 'retires rows that were not in this feed' do
+        gone = create(:derivative, security_id: '99999', last_seen_at: 3.days.ago)
+
+        described_class.import(mock_csv_path)
+
+        expect(gone.reload).not_to be_active
+      end
+
+      it 'records a failure rather than leaving no trace' do
+        allow(InstrumentsImport::Parser).to receive(:call).and_raise('bad feed')
+
+        expect { described_class.import(mock_csv_path) }.to raise_error('bad feed')
+        expect(InstrumentSyncRun.last).to have_attributes(status: 'failed', error_message: 'bad feed')
+      end
     end
 
     context 'when file_path is not provided' do
@@ -46,6 +96,42 @@ RSpec.describe InstrumentsImporter, type: :service do
       expect(summary[:derivative_total]).to eq(Derivative.count)
       expect(Instrument.segment_index.find_by(symbol_name: 'NIFTY')).to be_present
       expect(Derivative.count).to be >= 0
+    end
+
+    it 'does not retire anything, because the caller may be passing a partial feed' do
+      other = create(:derivative, security_id: '99999', last_seen_at: 3.days.ago)
+
+      described_class.new.import_from_csv(File.read(mock_csv_path))
+
+      expect(other.reload).to be_active
+    end
+
+    it 'is not recorded as a sync run' do
+      expect { described_class.new.import_from_csv(File.read(mock_csv_path)) }
+        .not_to change(InstrumentSyncRun, :count)
+    end
+  end
+
+  describe 'unparented contracts' do
+    it 'keeps a contract whose underlying is absent from the master' do
+      # BSE index options are the real case: the SENSEX50 index row is not
+      # always present, and the importer used to drop every contract on it.
+      described_class.import(mock_csv_path)
+
+      expect(Derivative.where(instrument_id: nil).count)
+        .to eq(InstrumentSyncRun.last_success.unparented_derivatives)
+    end
+  end
+
+  describe 'idempotency' do
+    it 'upserts rather than duplicating when run twice' do
+      described_class.import(mock_csv_path)
+
+      expect { described_class.import(mock_csv_path) }
+        .to not_change(Instrument, :count)
+        .and not_change(Derivative, :count)
+        .and not_change(OrderFeature, :count)
+        .and not_change(MarginRequirement, :count)
     end
   end
 end

--- a/spec/services/instruments_import/deactivator_spec.rb
+++ b/spec/services/instruments_import/deactivator_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InstrumentsImport::Deactivator, type: :service do
+  let(:started_at) { Time.current }
+
+  it 'retires rows the feed stopped listing' do
+    stale = create(:derivative, last_seen_at: started_at - 2.days)
+
+    described_class.call(started_at: started_at)
+
+    expect(stale.reload).not_to be_active
+  end
+
+  it 'leaves rows the current run stamped alone' do
+    fresh = create(:derivative, last_seen_at: started_at + 1.second)
+
+    described_class.call(started_at: started_at)
+
+    expect(fresh.reload).to be_active
+  end
+
+  it 'retires rows that predate the last_seen_at column' do
+    legacy = create(:instrument, last_seen_at: nil)
+
+    described_class.call(started_at: started_at)
+
+    expect(legacy.reload).not_to be_active
+  end
+
+  it 'reports how many rows it retired across both tables' do
+    create(:instrument, last_seen_at: started_at - 2.days)
+    create(:derivative, last_seen_at: started_at - 2.days)
+
+    expect(described_class.call(started_at: started_at)).to eq(deactivated_rows: 2)
+  end
+
+  it 'never deletes, because orders and positions still reference these rows' do
+    create(:derivative, last_seen_at: started_at - 2.days)
+
+    expect { described_class.call(started_at: started_at) }.not_to change(Derivative, :count)
+  end
+
+  it 'is idempotent — a second sweep does not re-count what it already retired' do
+    create(:derivative, last_seen_at: started_at - 2.days)
+    described_class.call(started_at: started_at)
+
+    expect(described_class.call(started_at: started_at)).to eq(deactivated_rows: 0)
+  end
+end

--- a/spec/services/instruments_import/parser_spec.rb
+++ b/spec/services/instruments_import/parser_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InstrumentsImport::Parser, type: :service do
+  # The detailed scrip master's column order, verbatim.
+  def headers
+    %w[
+      EXCH_ID SEGMENT SECURITY_ID ISIN INSTRUMENT UNDERLYING_SECURITY_ID UNDERLYING_SYMBOL
+      SYMBOL_NAME DISPLAY_NAME INSTRUMENT_TYPE SERIES LOT_SIZE SM_EXPIRY_DATE STRIKE_PRICE
+      OPTION_TYPE TICK_SIZE EXPIRY_FLAG BRACKET_FLAG COVER_FLAG ASM_GSM_FLAG ASM_GSM_CATEGORY
+      BUY_SELL_INDICATOR BUY_CO_MIN_MARGIN_PER SELL_CO_MIN_MARGIN_PER BUY_CO_SL_RANGE_MAX_PERC
+      SELL_CO_SL_RANGE_MAX_PERC BUY_CO_SL_RANGE_MIN_PERC SELL_CO_SL_RANGE_MIN_PERC
+      BUY_BO_MIN_MARGIN_PER SELL_BO_MIN_MARGIN_PER BUY_BO_SL_RANGE_MAX_PERC
+      SELL_BO_SL_RANGE_MAX_PERC BUY_BO_SL_RANGE_MIN_PERC SELL_BO_SL_MIN_RANGE
+      BUY_BO_PROFIT_RANGE_MAX_PERC SELL_BO_PROFIT_RANGE_MAX_PERC BUY_BO_PROFIT_RANGE_MIN_PERC
+      SELL_BO_PROFIT_RANGE_MIN_PERC MTF_LEVERAGE
+    ]
+  end
+
+  def csv_for(**overrides)
+    defaults = {
+      'EXCH_ID' => 'NSE', 'SEGMENT' => 'E', 'SECURITY_ID' => '2885', 'ISIN' => 'INE002A01018',
+      'INSTRUMENT' => 'EQUITY', 'UNDERLYING_SYMBOL' => 'RELIANCE',
+      'SYMBOL_NAME' => 'RELIANCE INDUSTRIES LTD', 'DISPLAY_NAME' => 'Reliance',
+      'INSTRUMENT_TYPE' => 'ES', 'SERIES' => 'EQ', 'LOT_SIZE' => '1', 'TICK_SIZE' => '0.05',
+      'BRACKET_FLAG' => 'Y', 'COVER_FLAG' => 'Y', 'ASM_GSM_FLAG' => 'N',
+      'ASM_GSM_CATEGORY' => 'NA', 'BUY_SELL_INDICATOR' => 'A',
+      'BUY_CO_MIN_MARGIN_PER' => '20.00', 'MTF_LEVERAGE' => '3.773585'
+    }.merge(overrides)
+
+    CSV.generate do |csv|
+      csv << headers
+      csv << headers.map { |h| defaults[h] }
+    end
+  end
+
+  it 'routes a cash-segment row to instruments' do
+    result = described_class.call(csv_for)
+
+    expect(result[:instruments].size).to eq(1)
+    expect(result[:derivatives]).to be_empty
+    expect(result[:instruments].first).to include(security_id: '2885', segment: 'E', active: true)
+  end
+
+  it 'routes a derivatives-segment row to derivatives' do
+    result = described_class.call(
+      csv_for('SEGMENT' => 'D', 'INSTRUMENT' => 'OPTIDX', 'SECURITY_ID' => '35024',
+              'SYMBOL_NAME' => 'NIFTY-Feb2025-29200-CE', 'UNDERLYING_SYMBOL' => 'NIFTY',
+              'SM_EXPIRY_DATE' => '2025-02-27', 'STRIKE_PRICE' => '29200.00000',
+              'OPTION_TYPE' => 'CE', 'EXPIRY_FLAG' => 'W')
+    )
+
+    expect(result[:instruments]).to be_empty
+    expect(result[:derivatives].first).to include(
+      security_id: '35024', option_type: 'CE', expiry_date: Date.new(2025, 2, 27)
+    )
+  end
+
+  it 'skips exchanges this app does not trade' do
+    expect(described_class.call(csv_for('EXCH_ID' => 'XYZ'))[:instruments]).to be_empty
+  end
+
+  describe 'trading rules' do
+    it 'splits the flags onto order_features rather than the wide table' do
+      result = described_class.call(csv_for)
+
+      expect(result[:order_features].first).to include(
+        bracket_flag: 'Y', cover_flag: 'Y', buy_sell_indicator: 'A',
+        asm_gsm_flag: 'N', asm_gsm_category: 'NA', mtf_leverage: 3.773585,
+        owner_type: 'Instrument'
+      )
+      expect(result[:instruments].first.keys).not_to include(:bracket_flag, :asm_gsm_flag, :mtf_leverage)
+    end
+
+    it 'keeps the exchange Y/N for a derivative instead of coercing it to a boolean' do
+      result = described_class.call(
+        csv_for('SEGMENT' => 'D', 'INSTRUMENT' => 'OPTIDX', 'ASM_GSM_FLAG' => 'Y',
+                'SM_EXPIRY_DATE' => '2025-02-27', 'OPTION_TYPE' => 'CE', 'STRIKE_PRICE' => '100')
+      )
+
+      # The previous parser assigned `row['ASM_GSM_FLAG'] == 'Y'` — a boolean —
+      # into a string column, which stored "true"/"false".
+      expect(result[:order_features].first).to include(asm_gsm_flag: 'Y', owner_type: 'Derivative')
+    end
+
+    it 'splits the CO/BO percentages onto margin_requirements' do
+      result = described_class.call(csv_for)
+
+      expect(result[:margin_requirements].first).to include(
+        buy_co_min_margin_per: 20.0, owner_type: 'Instrument'
+      )
+    end
+
+    it 'emits no satellite rows when the master carries no rules' do
+      blank = headers.index_with { '' }.merge(
+        'EXCH_ID' => 'NSE', 'SEGMENT' => 'E', 'SECURITY_ID' => '1',
+        'SYMBOL_NAME' => 'X', 'INSTRUMENT' => 'EQUITY'
+      )
+      csv = CSV.generate do |out|
+        out << headers
+        out << headers.map { |h| blank[h] }
+      end
+
+      result = described_class.call(csv)
+
+      expect(result[:order_features]).to be_empty
+      expect(result[:margin_requirements]).to be_empty
+    end
+
+    it 'keys satellites to the owner natural key so they can be linked after upsert' do
+      result = described_class.call(csv_for)
+
+      expect(result[:order_features].first[:owner_key])
+        .to eq(['2885', 'RELIANCE INDUSTRIES LTD', 'NSE', 'E'])
+    end
+  end
+
+  it 'never emits the generated exchange_segment column, which Postgres refuses writes to' do
+    result = described_class.call(csv_for)
+
+    expect(result[:instruments].first.keys).not_to include(:exchange_segment)
+  end
+end

--- a/spec/services/orders/risk_manager_spec.rb
+++ b/spec/services/orders/risk_manager_spec.rb
@@ -143,9 +143,6 @@ RSpec.describe Orders::RiskManager, type: :service do
                           series: 'X',
                           lot_size: 1,
                           tick_size: 1.0,
-                          asm_gsm_flag: 'N',
-                          asm_gsm_category: 'NA',
-                          mtf_leverage: 0.0,
                           created_at: '2025-06-28 00:59:32.511118000 +0530',
                           updated_at: '2025-06-28 00:59:32.511118000 +0530')
     end

--- a/spec/support/negated_matchers.rb
+++ b/spec/support/negated_matchers.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# `expect { ... }.to change(X, :count).by(0)` reads as "it changed by zero";
+# `not_change` says what is actually meant and composes with `.and`, which is
+# how idempotency is asserted across several tables at once.
+RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
The scrip master's 22 trading-rule columns were duplicated onto both
`instruments` and `derivatives` while the polymorphic satellites built for
them — `order_features` and `margin_requirements` — were never written to.
The parser sliced one flat hash by `column_names`, so 16 of the 22 columns
were NULL in every row and the other six sat in the middle of the two
tables every tick and every order touches.

Finish the normalization the schema already described:

- Backfill `order_features` (bracket/cover/buy-sell flags, ASM/GSM status,
  MTF leverage) and `margin_requirements` (the CO/BO percentages) from the
  wide columns, then drop those columns from both tables. Satellites become
  has_one, which is what their unique indexes already enforced and what
  `ransackable_associations` already named.
- Add `active` and `last_seen_at`. Nothing ever retired a row, so every
  expired weekly option stayed resolvable as a tradable contract. Rows the
  feed stops listing are flagged, never deleted — orders and positions still
  reference them by security_id.
- Add `exchange_segment` as a stored generated column so the key every
  DhanHQ call and every WebSocket tick is addressed by can be indexed
  instead of recomputed in Ruby.
- Index the three lookups actually performed: (exchange_segment,
  security_id) for tick mapping, (underlying_symbol, expiry_date,
  strike_price, option_type) for the option chain, and (instrument_id,
  expiry_date) for expiry discovery. Column order on the chain index matches
  the scope's ORDER BY; resolving a strike before an order is an index
  condition on all four columns.
- Replace the eight loose `app_settings` strings with `instrument_sync_runs`,
  which keeps history and can record a failure. A crashed import was
  previously indistinguishable from one that never ran.

Fixes found along the way:

- The parser assigned `ASM_GSM_FLAG == 'Y'` — a boolean — into a string
  column for derivatives, storing "true"/"false" so no Y/N test matched.
- `instrument_id` was NOT NULL and unparented contracts were discarded, so a
  derivative whose underlying was missing from the master (BSE index options)
  could never be resolved. It is nullable now and those rows are kept.
- `Instrument` validated `security_id` globally unique, but a DhanHQ
  security_id is unique only within an exchange segment.
- `Derivative` required a strike and CE/PE type, rejecting every future.
- Four callers queried columns that do not exist — `instrument:` instead of
  `instrument_code:` in the two derivative-flag checks and the factor engine,
  and `trading_symbol:` in the candle tool. Two were inside a
  `rescue StandardError` that turned the resulting StatementInvalid into
  "no derivatives exist" for every symbol.
- `instruments:status` read a `Setting` constant and a `CACHE_MAX_AGE` that
  neither exist; it now reads the sync-run table.

Also stream the CSV rather than materializing every row up front.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GXDmj5DQLkSow7YWZvcpad