### PR TITLE
Add crypto SMC/ICT scanner for SOLUSDT and ETHUSDT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,53 @@ OLLAMA_DEFAULT_MODEL=qwen3-coder:480b-cloud
 # Per-attempt HTTP behaviour. Key rotation happens above these retries.
 LLM_REQUEST_TIMEOUT=120
 LLM_MAX_RETRIES=2
+
+# ── Crypto SMC/ICT scanner ───────────────────────────────────────────────
+# Analysis-only scanner over Binance USD-M futures market data. It reads
+# public endpoints (no API key exists for it to hold), never places an order,
+# persists nothing, and notifies Telegram only when a LONG or SHORT setup
+# clears every gate. The DhanHQ path is untouched by all of it.
+#
+# Master switch. Everything below is inert while this is false.
+CRYPTO_SMC_ENABLED=false
+
+# Pairs to analyse, comma separated. Defaults to SOLUSDT,ETHUSDT.
+CRYPTO_SMC_SYMBOLS=SOLUSDT,ETHUSDT
+
+# Timeframes are fixed by the top-down method: 1d and 4h set bias, 1h carries
+# structure and premium/discount, 15m holds the POI, 5m is execution. Only the
+# stream subscription is configurable — the other closes are covered by the
+# safety-net scan.
+CRYPTO_SMC_STREAM_TIMEFRAMES=5m,15m
+
+# Alert gates. Score is the weighted confluence total normalised to 100; a
+# setup also needs a 5m trigger and this reward:risk to the first target.
+CRYPTO_SMC_MIN_SCORE=62
+CRYPTO_SMC_MIN_RR=1.8
+
+# Silence window per symbol + side + point of interest. Structure does not
+# change every five minutes, and without this the same setup re-alerts on
+# every scan.
+CRYPTO_SMC_COOLDOWN_MINUTES=45
+
+# Widest publishable stop, as a multiple of the 15m ATR. Beyond this the entry
+# has already run away from the level.
+CRYPTO_SMC_MAX_STOP_ATR=2.5
+
+# Fractal width for swing detection (bars either side of a pivot).
+CRYPTO_SMC_SWING_STRENGTH=2
+
+# Where alerts go. Falls back to TELEGRAM_CHAT_ID when unset.
+CRYPTO_TELEGRAM_CHAT_ID=
+
+# Start the kline stream inside the web process instead of running
+# `rake crypto:stream` as its own process. See config/initializers/
+# crypto_smc_scanner.rb for why a multi-worker Puma duplicates the socket.
+CRYPTO_SMC_AUTOSTART=false
+
+# inline: the stream runs the scan on EventMachine's thread pool (default).
+# enqueue: it hands the scan to Active Job instead.
+CRYPTO_SMC_STREAM_MODE=inline
+
+# Override the Binance USD-M base URL (e.g. https://testnet.binancefuture.com).
+CRYPTO_BINANCE_BASE=https://fapi.binance.com

--- a/README.md
+++ b/README.md
@@ -305,6 +305,39 @@ hit the live API — so a full strategy can be rehearsed against real prices.
 This is distinct from `PLACE_ORDER=false`, which short-circuits in this app
 before the SDK is called at all.
 
+## ₿ Crypto SMC/ICT scanner (analysis only)
+
+A scanner for **SOLUSDT** and **ETHUSDT** on Binance USD-M futures, running
+alongside — and entirely independent of — the DhanHQ path. It reads Smart Money
+Concepts / ICT structure top-down across `1d`, `4h`, `1h`, `15m` and `5m`
+(execution), and sends a Telegram message **only when a LONG or SHORT setup
+clears every gate**.
+
+- **Places no orders and holds no keys** — `Crypto::Binance::Client` has no
+  signed-request path at all, only public market data.
+- **Persists nothing** — candles are fetched, analysed and dropped. The Telegram
+  message is the entire output; there is no model and no migration.
+- **Reads**: market structure (BOS/CHoCH on closes), order blocks, fair value
+  gaps, liquidity pools and sweeps, premium/discount + OTE, displacement.
+- **Gates**: a 5m trigger is mandatory, the 1d and 4h biases must not both
+  oppose, and the setup needs a confluence score ≥ 62/100 and R:R ≥ 1.8.
+- **Runs**: event-based on candle close (`rake crypto:stream`, which also
+  carries a 5-minute safety-net sweep) and/or scheduled via
+  `Crypto::SmcScanJob`.
+
+```bash
+CRYPTO_SMC_ENABLED=true bundle exec rake crypto:stream   # event-driven listener
+rake crypto:report SYMBOL=ETHUSDT                        # full MTF read, no alert
+rake crypto:scan                                         # scan and alert now
+rake crypto:config                                       # resolved settings
+```
+
+Everything is inert unless `CRYPTO_SMC_ENABLED=true`. Note that Binance answers
+**HTTP 451** from restricted regions, including many cloud IP ranges — see the
+docs for `CRYPTO_BINANCE_BASE`.
+
+Full docs: **[docs/CRYPTO_SMC.md](docs/CRYPTO_SMC.md)**.
+
 ## 🤖 MCP (Model Context Protocol)
 
 The app exposes a **read-only DhanHQ MCP server** over HTTP so AI assistants (e.g. Cursor) and other MCP clients can call broker and market tools via JSON-RPC.

--- a/app/jobs/crypto/smc_scan_job.rb
+++ b/app/jobs/crypto/smc_scan_job.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Crypto
+  # Scheduled sweep: analyse every configured pair and alert on what qualifies.
+  #
+  # Deliberately **not** an `ApplicationJob`. That base class runs
+  # `ensure_dhan_token!` before every perform and re-raises when the token
+  # cannot be minted, which would take the crypto scanner down every time the
+  # Dhan session lapsed — an unrelated broker, an unrelated market, and one
+  # that is closed at most of the hours this job runs. Binance market data
+  # needs no credential at all.
+  #
+  # Retries are off for the same reason a stale scan is worse than a missed
+  # one: by the time a retry lands, the 5m candle that triggered it has been
+  # replaced, and an alert on it would describe a chart that no longer exists.
+  # The next scheduled run is the retry.
+  # rubocop:disable Rails/ApplicationJob -- see the note above: ApplicationJob
+  # mints a DhanHQ token before every perform and re-raises on failure, which
+  # this job must not depend on.
+  class SmcScanJob < ActiveJob::Base
+    # rubocop:enable Rails/ApplicationJob
+    queue_as :default
+
+    discard_on StandardError do |job, error|
+      Rails.logger.error("[Crypto::SmcScanJob] discarded: #{error.class} - #{error.message}")
+      Rails.logger.error("[Crypto::SmcScanJob] args=#{job.arguments.inspect}")
+    end
+
+    # @param symbols [Array<String>, String, nil] nil scans everything configured
+    def perform(symbols = nil)
+      unless Config.enabled?
+        Rails.logger.debug('[Crypto::SmcScanJob] skipped — CRYPTO_SMC_ENABLED is not true')
+        return
+      end
+
+      results = Scanner.call(symbols: Array(symbols).presence)
+      log(results)
+      results
+    end
+
+    private
+
+    def log(results)
+      if results.empty?
+        Rails.logger.info('[Crypto::SmcScanJob] no qualifying setups')
+        return
+      end
+
+      results.each do |result|
+        Rails.logger.info(
+          "[Crypto::SmcScanJob] #{result.symbol} #{result.setup.side} " \
+          "score=#{result.setup.score} rr=#{result.setup.risk_reward} status=#{result.status}"
+        )
+      end
+    end
+  end
+end

--- a/app/services/crypto/alert_dispatcher.rb
+++ b/app/services/crypto/alert_dispatcher.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module Crypto
+  # Sends a {Setup} to Telegram, once.
+  #
+  # The whole point of the scanner is that it only speaks when there is
+  # something to say, so suppression is as much a feature as sending. Two
+  # layers do it, because two different processes dispatch:
+  #
+  #   * an in-process hash — free, and enough for repeated scans in one worker
+  #   * `Rails.cache` — shared, so the scheduled job and the event-driven
+  #     stream runner do not both announce the same setup from their own
+  #     processes seconds apart
+  #
+  # The cache entry is a short-lived mutex keyed on the setup's identity, not
+  # a record of the analysis: nothing about the setup is stored, and the key
+  # expires with the cooldown.
+  class AlertDispatcher
+    class << self
+      # @return [Symbol] :sent, :suppressed, :unconfigured or :failed
+      def dispatch(setup)
+        return :unconfigured if chat_id.blank?
+        return :suppressed if recent?(setup.dedupe_key)
+
+        remember(setup.dedupe_key)
+        deliver(setup)
+      end
+
+      # Test seam — the in-process half of the cooldown outlives an example
+      # otherwise, since it is deliberately class-level state.
+      def reset!
+        mutex.synchronize { store.clear }
+      end
+
+      private
+
+      def deliver(setup)
+        TelegramNotifier.send_message(SetupFormatter.call(setup), chat_id: chat_id)
+        Rails.logger.info("[Crypto] alerted #{setup.symbol} #{setup.side} score=#{setup.score} rr=#{setup.risk_reward}")
+        :sent
+      rescue StandardError => e
+        Rails.logger.error("[Crypto] Telegram dispatch failed for #{setup.symbol}: #{e.class} - #{e.message}")
+        :failed
+      end
+
+      def recent?(key)
+        return true if in_process_recent?(key)
+
+        shared_recent?(key)
+      end
+
+      def in_process_recent?(key)
+        mutex.synchronize do
+          expiry = store[key]
+          next false if expiry.nil?
+          next true if expiry > Time.current
+
+          store.delete(key)
+          false
+        end
+      end
+
+      def shared_recent?(key)
+        Rails.cache.read(cache_key(key)).present?
+      rescue StandardError => e
+        Rails.logger.warn("[Crypto] shared cooldown unavailable: #{e.class} - #{e.message}")
+        false
+      end
+
+      def remember(key)
+        cooldown = Config.cooldown_seconds
+        mutex.synchronize do
+          purge_expired
+          store[key] = Time.current + cooldown
+        end
+
+        begin
+          Rails.cache.write(cache_key(key), true, expires_in: cooldown)
+        rescue StandardError => e
+          Rails.logger.warn("[Crypto] could not write shared cooldown: #{e.class} - #{e.message}")
+        end
+      end
+
+      # Called under the mutex.
+      def purge_expired
+        now = Time.current
+        store.delete_if { |_, expiry| expiry <= now }
+      end
+
+      def cache_key(key) = "crypto:smc:alert:#{key}"
+
+      def chat_id = Config.telegram_chat_id
+
+      def store
+        @store ||= {}
+      end
+
+      def mutex
+        @mutex ||= Mutex.new
+      end
+    end
+  end
+end

--- a/app/services/crypto/analyzer.rb
+++ b/app/services/crypto/analyzer.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Crypto
+  # Fetches the multi-timeframe picture for one symbol and runs the detector.
+  #
+  #   Crypto::Analyzer.call('SOLUSDT') # => Crypto::Setup or nil
+  #
+  # Nothing is written anywhere: candles are fetched, analysed and dropped.
+  # A scan is a pure read of Binance's public market data, which is what makes
+  # it safe to run alongside the DhanHQ order path without touching it.
+  class Analyzer
+    def self.call(...) = new(...).call
+
+    def initialize(symbol, client: nil, timeframes: Config::TIMEFRAMES)
+      @symbol     = Binance::Client.new.normalize_symbol(symbol)
+      @client     = client || Binance::Client.new
+      @timeframes = timeframes
+    end
+
+    attr_reader :symbol
+
+    # @return [Crypto::Setup, nil]
+    def call
+      reports = build_reports
+      return nil if reports.nil?
+
+      SetupDetector.call(symbol: symbol, reports: reports)
+    end
+
+    # The same analysis without the gates — every timeframe's read, for the
+    # `crypto:report` task and for debugging why a chart did *not* alert.
+    def reports
+      @reports ||= build_reports
+    end
+
+    private
+
+    def build_reports
+      out = {}
+
+      @timeframes.each do |timeframe|
+        series = fetch(timeframe)
+        return nil if series.nil? || series.size < 30
+
+        out[timeframe] = Smc::TimeframeReport.new(series)
+      end
+
+      out
+    rescue StandardError => e
+      Rails.logger.error("[Crypto::Analyzer] #{symbol} analysis failed: #{e.class} - #{e.message}")
+      nil
+    end
+
+    def fetch(timeframe)
+      @client.series(symbol: symbol, interval: timeframe, limit: Config::CANDLE_LIMITS.fetch(timeframe, 200))
+    rescue Binance::Error => e
+      Rails.logger.error("[Crypto::Analyzer] #{symbol} #{timeframe} fetch failed: #{e.message}")
+      nil
+    end
+  end
+end

--- a/app/services/crypto/binance/client.rb
+++ b/app/services/crypto/binance/client.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+require 'json'
+
+module Crypto
+  module Binance
+    class Error < StandardError; end
+
+    # Read-only client for Binance USD-M futures market data.
+    #
+    # Every endpoint used here is public — klines, ticker and mark price carry
+    # no signature and need no API key, which is the whole point: this scanner
+    # analyses and notifies, it never trades. There is deliberately no signed
+    # request path in this class, so a leaked deploy cannot place an order
+    # through it.
+    class Client
+      DEFAULT_BASE = 'https://fapi.binance.com'
+      OPEN_TIMEOUT = 5
+      READ_TIMEOUT = 10
+      MAX_ATTEMPTS = 3
+
+      # Binance caps klines at 1500 per request.
+      MAX_LIMIT = 1500
+
+      def initialize(base_url: nil)
+        @base_url = (base_url || ENV['CRYPTO_BINANCE_BASE'].presence || DEFAULT_BASE).chomp('/')
+      end
+
+      attr_reader :base_url
+
+      # @param symbol [String] e.g. "SOLUSDT"
+      # @param interval [String] e.g. "15m", "4h", "1d"
+      # @param limit [Integer] number of bars, oldest first
+      # @return [Array<Array>] raw kline rows
+      def klines(symbol:, interval:, limit: 200)
+        get('/fapi/v1/klines',
+            symbol: normalize_symbol(symbol),
+            interval: interval,
+            limit: [limit.to_i, MAX_LIMIT].min)
+      end
+
+      # Convenience wrapper returning a ready-to-analyse {Crypto::Series}.
+      def series(symbol:, interval:, limit: 200)
+        rows = klines(symbol: symbol, interval: interval, limit: limit)
+        Series.from_binance(symbol: normalize_symbol(symbol), timeframe: interval, rows: rows)
+      end
+
+      # @return [Float] last traded price
+      def last_price(symbol)
+        body = get('/fapi/v1/ticker/price', symbol: normalize_symbol(symbol))
+        body['price'].to_f
+      end
+
+      # @return [Hash] mark price, index price and current funding rate
+      def premium_index(symbol)
+        get('/fapi/v1/premiumIndex', symbol: normalize_symbol(symbol))
+      end
+
+      # Accepts "SOLUSDT", "solusdt", "SOL/USDT" or "SOL-USDT".
+      def normalize_symbol(symbol)
+        symbol.to_s.upcase.gsub(%r{[/\-_ ]}, '')
+      end
+
+      private
+
+      def get(path, **params)
+        uri = URI.join(base_url, path)
+        uri.query = URI.encode_www_form(params.compact)
+
+        body = request_with_retries(uri)
+        JSON.parse(body)
+      rescue JSON::ParserError => e
+        raise Error, "Binance returned unparseable JSON from #{path}: #{e.message}"
+      end
+
+      def request_with_retries(uri)
+        attempt = 0
+        begin
+          attempt += 1
+          perform(uri)
+        rescue Error
+          # An API-level rejection (bad symbol, bad interval) fails identically
+          # on every attempt; only transport faults are worth retrying.
+          raise
+        rescue StandardError => e
+          raise Error, "Binance request failed after #{attempt} attempts: #{e.class} - #{e.message}" if attempt >= MAX_ATTEMPTS
+
+          sleep(0.4 * attempt)
+          retry
+        end
+      end
+
+      def perform(uri)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == 'https'
+        http.open_timeout = OPEN_TIMEOUT
+        http.read_timeout = READ_TIMEOUT
+
+        response = http.request(Net::HTTP::Get.new(uri))
+        return response.body if response.is_a?(Net::HTTPSuccess)
+
+        raise Error, "Binance #{uri.path} responded #{response.code}: #{response.body.to_s.truncate(200)}"
+      end
+    end
+  end
+end

--- a/app/services/crypto/binance/kline_stream.rb
+++ b/app/services/crypto/binance/kline_stream.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'faye/websocket'
+require 'eventmachine'
+require 'json'
+
+module Crypto
+  module Binance
+    # Event-driven half of the scanner: a combined Binance kline stream that
+    # runs the analysis the moment a candle closes.
+    #
+    # The scheduled job is a safety net on a fixed cadence; this is the one
+    # that matters, because an SMC read is only meaningful on closed candles.
+    # Binance marks that explicitly with `k.x`, so nothing here has to guess
+    # from timestamps — an in-progress bar is ignored outright, which is also
+    # what stops the scanner reacting to a wick that is about to be filled.
+    #
+    # One socket carries every symbol × timeframe pair. Binance closes a
+    # stream after 24 hours by design, so reconnect is a normal event, not an
+    # error path.
+    class KlineStream
+      BASE = 'wss://fstream.binance.com'
+
+      RECONNECT_BASE_DELAY = 2
+      RECONNECT_MAX_DELAY  = 60
+
+      # Two timeframes can close on the same second (every 15m, the 5m closes
+      # too). Without this, one candle boundary would fire two identical scans.
+      DEBOUNCE_SECONDS = 20
+
+      # Safety-net sweep. This app has no scheduler — Solid Queue's recurring
+      # tasks need `bin/jobs` running and the deployed adapter is `:async`, and
+      # there is no cron service — so the interval scan lives here rather than
+      # in a crontab that may not exist. It only fires for a symbol the stream
+      # has not already covered, so a healthy socket makes it a no-op.
+      SAFETY_SCAN_INTERVAL = 300
+
+      attr_reader :symbols, :timeframes
+
+      def initialize(symbols: nil, timeframes: nil, on_close: nil)
+        @symbols    = Array(symbols.presence || Config.symbols).map(&:upcase)
+        @timeframes = Array(timeframes.presence || Config.stream_timeframes)
+        @on_close   = on_close || method(:default_handler)
+        @last_fired = {}
+        @attempts   = 0
+      end
+
+      # Blocks, running an EventMachine reactor. Intended for a dedicated
+      # process (`rails crypto:stream`), never a web request.
+      def run
+        EM.run do
+          connect
+          start_safety_timer
+        end
+      end
+
+      def stream_url
+        streams = symbols.product(timeframes).map { |symbol, tf| "#{symbol.downcase}@kline_#{tf}" }
+        "#{BASE}/stream?streams=#{streams.join('/')}"
+      end
+
+      private
+
+      def connect
+        url = stream_url
+        Rails.logger.info("[Crypto::KlineStream] connecting: #{url}")
+        socket = Faye::WebSocket::Client.new(url, [], ping: 60)
+
+        socket.on(:open) do
+          @attempts = 0
+          Rails.logger.info("[Crypto::KlineStream] connected — #{symbols.join(', ')} @ #{timeframes.join(', ')}")
+        end
+
+        socket.on(:message) { |event| handle_message(event.data) }
+        socket.on(:error)   { |event| Rails.logger.error("[Crypto::KlineStream] error: #{event.message}") }
+        socket.on(:close) do |event|
+          Rails.logger.warn("[Crypto::KlineStream] closed (#{event.code}) #{event.reason} — reconnecting")
+          schedule_reconnect
+        end
+      end
+
+      # Covers the window where the socket is down, or where Binance stopped
+      # publishing without closing the connection. A symbol the stream already
+      # scanned inside the interval is skipped.
+      def start_safety_timer
+        EM.add_periodic_timer(SAFETY_SCAN_INTERVAL) do
+          stale = symbols.reject { |symbol| recently_scanned?(symbol) }
+          next if stale.empty?
+
+          Rails.logger.info("[Crypto::KlineStream] safety scan for #{stale.join(', ')}")
+          stale.each { |symbol| @on_close.call(symbol, 'safety') }
+        end
+      end
+
+      def recently_scanned?(symbol)
+        last = @last_fired[symbol]
+        last.present? && (Time.current - last) < SAFETY_SCAN_INTERVAL
+      end
+
+      def schedule_reconnect
+        @attempts += 1
+        delay = [RECONNECT_BASE_DELAY * (2**(@attempts - 1)), RECONNECT_MAX_DELAY].min
+        EM.add_timer(delay) { connect }
+      end
+
+      def handle_message(raw)
+        payload = JSON.parse(raw)
+        kline = payload.dig('data', 'k') || payload['k']
+        return if kline.nil?
+        return unless kline['x'] # candle still forming
+
+        # Binance repeats the symbol at the event level and inside the kline.
+        # Read both: a combined stream nests the event under "data", a raw
+        # single stream does not, and only the inner copy is common to both.
+        symbol = payload.dig('data', 's') || payload['s'] || kline['s']
+        timeframe = kline['i']
+        return if symbol.blank?
+        return unless fire?(symbol)
+
+        Rails.logger.info("[Crypto::KlineStream] #{symbol} #{timeframe} closed at #{kline['c']} — scanning")
+        @on_close.call(symbol, timeframe)
+      rescue JSON::ParserError => e
+        Rails.logger.error("[Crypto::KlineStream] unparseable frame: #{e.message}")
+      rescue StandardError => e
+        Rails.logger.error("[Crypto::KlineStream] handler failed: #{e.class} - #{e.message}")
+      end
+
+      def fire?(symbol)
+        now = Time.current
+        last = @last_fired[symbol]
+        return false if last && (now - last) < DEBOUNCE_SECONDS
+
+        @last_fired[symbol] = now
+        true
+      end
+
+      # A scan makes several HTTPS round trips, so it must never run on the
+      # reactor thread — a blocked reactor stops reading frames and the socket
+      # dies. `EM.defer` hands it to the thread pool; the enqueue mode exists
+      # for deployments that would rather the worker do it.
+      def default_handler(symbol, _timeframe)
+        if enqueue_mode?
+          SmcScanJob.perform_later([symbol])
+        else
+          EM.defer { run_scan(symbol) }
+        end
+      end
+
+      def run_scan(symbol)
+        Scanner.call(symbols: [symbol])
+      rescue StandardError => e
+        Rails.logger.error("[Crypto::KlineStream] scan failed for #{symbol}: #{e.class} - #{e.message}")
+      ensure
+        ActiveRecord::Base.connection_handler.clear_active_connections! if defined?(ActiveRecord::Base)
+      end
+
+      def enqueue_mode?
+        ENV.fetch('CRYPTO_SMC_STREAM_MODE', 'inline').to_s.downcase == 'enqueue'
+      end
+    end
+  end
+end

--- a/app/services/crypto/candle.rb
+++ b/app/services/crypto/candle.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Crypto
+  # Immutable OHLCV bar for a crypto pair.
+  #
+  # Deliberately *not* the app's top-level `Candle`: that one rounds every
+  # price through `PriceMath.round_tick` (an NSE 0.05 tick) and casts volume
+  # with `to_i`. Both are wrong here — ETHUSDT prints to two decimals on a
+  # 0.01 tick, SOLUSDT to three, and Binance reports fractional base volume.
+  class Candle
+    attr_reader :timestamp, :open, :high, :low, :close, :volume
+
+    # @param ts [Time, Integer] bar open time; Integer is read as epoch millis
+    def initialize(ts:, open:, high:, low:, close:, volume: 0)
+      @timestamp = coerce_time(ts)
+      @open      = open.to_f
+      @high      = high.to_f
+      @low       = low.to_f
+      @close     = close.to_f
+      @volume    = volume.to_f
+    end
+
+    # Binance returns klines as positional arrays:
+    # [open_time, open, high, low, close, volume, close_time, ...]
+    def self.from_binance(row)
+      new(ts: row[0], open: row[1], high: row[2], low: row[3], close: row[4], volume: row[5])
+    end
+
+    def bullish? = close > open
+    def bearish? = close < open
+    def doji?    = (close - open).abs < (range * 0.05)
+
+    def body        = (close - open).abs
+    def range       = high - low
+    def upper_wick  = high - [open, close].max
+    def lower_wick  = [open, close].min - low
+    def midpoint    = (high + low) / 2.0
+
+    # Share of the bar that is body rather than wick. Displacement candles run
+    # high; indecision bars run low.
+    def body_ratio
+      return 0.0 if range.zero?
+
+      body / range
+    end
+
+    def to_h
+      { timestamp: timestamp, open: open, high: high, low: low, close: close, volume: volume }
+    end
+
+    private
+
+    def coerce_time(ts)
+      case ts
+      when Time, ActiveSupport::TimeWithZone then ts
+      when Numeric then Time.zone.at(ts / 1000.0)
+      else Time.zone.parse(ts.to_s)
+      end
+    end
+  end
+end

--- a/app/services/crypto/config.rb
+++ b/app/services/crypto/config.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Crypto
+  # Every knob the SMC scanner reads, in one place.
+  #
+  # This module is deliberately env-driven and stateless: the scanner persists
+  # nothing, so configuration is the only state it has. Defaults are the ones
+  # the desk actually runs with — SOLUSDT and ETHUSDT on Binance USD-M futures,
+  # analysed top-down on 1d/4h/1h/15m with 5m as the execution timeframe.
+  module Config
+    # Analysis timeframes, highest first. The last entry is the execution
+    # timeframe and is treated specially by SetupDetector: a setup is never
+    # emitted without a trigger on it.
+    HTF_TIMEFRAMES       = %w[1d 4h].freeze
+    STRUCTURE_TIMEFRAME  = '1h'
+    SETUP_TIMEFRAME      = '15m'
+    EXECUTION_TIMEFRAME  = '5m'
+
+    TIMEFRAMES = [*HTF_TIMEFRAMES, STRUCTURE_TIMEFRAME, SETUP_TIMEFRAME, EXECUTION_TIMEFRAME].freeze
+
+    # How many candles to pull per timeframe. Enough history for structure to
+    # have several swings to work with, not so much that a scan is slow.
+    CANDLE_LIMITS = {
+      '1d' => 180,
+      '4h' => 250,
+      '1h' => 300,
+      '15m' => 300,
+      '5m' => 300
+    }.freeze
+
+    DEFAULT_SYMBOLS = %w[SOLUSDT ETHUSDT].freeze
+
+    module_function
+
+    # Master switch. The scanner is opt-in so that adding it to this app
+    # changes nothing about an existing DhanHQ deployment until asked.
+    def enabled?
+      ENV.fetch('CRYPTO_SMC_ENABLED', 'false').to_s.downcase == 'true'
+    end
+
+    # @return [Array<String>] uppercased Binance symbols, e.g. ["SOLUSDT"]
+    def symbols
+      raw = ENV.fetch('CRYPTO_SMC_SYMBOLS', '').to_s
+      list = raw.split(',').map { |s| s.strip.upcase }.reject(&:empty?)
+      list.presence || DEFAULT_SYMBOLS
+    end
+
+    # Confluence score (0-100) a candidate must reach to be alerted.
+    def min_score
+      ENV.fetch('CRYPTO_SMC_MIN_SCORE', '62').to_f
+    end
+
+    # Minimum reward:risk to the first target. Below this the setup is real
+    # but not worth taking, and an alert would be noise.
+    def min_risk_reward
+      ENV.fetch('CRYPTO_SMC_MIN_RR', '1.8').to_f
+    end
+
+    # Silence window per symbol+direction. Structure does not change every
+    # five minutes; without this the same setup re-alerts on every scan.
+    def cooldown_seconds
+      ENV.fetch('CRYPTO_SMC_COOLDOWN_MINUTES', '45').to_f * 60
+    end
+
+    # Widest stop we will publish, as a multiple of the 15m ATR. A stop beyond
+    # this means the POI is stale and the entry has already run away.
+    def max_stop_atr_multiple
+      ENV.fetch('CRYPTO_SMC_MAX_STOP_ATR', '2.5').to_f
+    end
+
+    # Fractal width for swing detection: a pivot needs this many bars either
+    # side. 2 is the ICT standard three-bar-plus fractal.
+    def swing_strength
+      ENV.fetch('CRYPTO_SMC_SWING_STRENGTH', '2').to_i
+    end
+
+    def telegram_chat_id
+      ENV['CRYPTO_TELEGRAM_CHAT_ID'].presence || ENV.fetch('TELEGRAM_CHAT_ID', nil)
+    end
+
+    # Streams the event-based runner subscribes to. Only closed candles on
+    # these timeframes trigger a scan; 1h/4h/1d closes are covered by the
+    # scheduled scan.
+    def stream_timeframes
+      raw = ENV.fetch('CRYPTO_SMC_STREAM_TIMEFRAMES', '5m,15m').to_s
+      list = raw.split(',').map { |s| s.strip.downcase }.reject(&:empty?)
+      list.presence || %w[5m 15m]
+    end
+  end
+end

--- a/app/services/crypto/formatting.rb
+++ b/app/services/crypto/formatting.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Crypto
+  # Price and percentage rendering for notifications.
+  #
+  # Crypto pairs do not share a tick size — ETHUSDT quotes to two decimals,
+  # SOLUSDT to three, and a smaller pair to four or five. Rather than carry a
+  # per-symbol tick table for what is only ever display, precision is chosen
+  # from the magnitude of the number itself, which gets every USDT perp right
+  # without a lookup that could go stale.
+  module Formatting
+    module_function
+
+    def price(value)
+      return '—' if value.nil?
+
+      value = value.to_f
+      decimals =
+        case value.abs
+        when 0...1 then 5
+        when 1...20 then 4
+        when 20...1_000 then 3
+        else 2
+        end
+
+      format("%.#{decimals}f", value)
+    end
+
+    def percent(value, decimals: 2)
+      return '—' if value.nil?
+
+      "#{format("%.#{decimals}f", value.to_f)}%"
+    end
+
+    # Signed distance from `from` to `to`, as a percentage of `from`.
+    def move_percent(from, to)
+      return '—' if from.nil? || to.nil? || from.to_f.zero?
+
+      percent(((to.to_f - from.to_f) / from.to_f) * 100)
+    end
+  end
+end

--- a/app/services/crypto/scanner.rb
+++ b/app/services/crypto/scanner.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Crypto
+  # Runs the analysis across the configured symbols and dispatches whatever
+  # qualifies. This is the single entry point both triggers use — the
+  # scheduled job and the WebSocket runner — so the two cannot drift apart in
+  # what they consider a setup.
+  #
+  #   Crypto::Scanner.call                          # every configured symbol
+  #   Crypto::Scanner.call(symbols: %w[SOLUSDT])    # one, after a 5m close
+  #   Crypto::Scanner.call(notify: false)           # analyse, say nothing
+  class Scanner
+    Result = Struct.new(:symbol, :setup, :status, keyword_init: true) do
+      def alerted? = status == :sent
+    end
+
+    def self.call(...) = new(...).call
+
+    def initialize(symbols: nil, notify: true, client: nil)
+      @symbols = Array(symbols.presence || Config.symbols)
+      @notify  = notify
+      @client  = client || Binance::Client.new
+    end
+
+    # @return [Array<Result>] one entry per symbol that produced a setup
+    def call
+      @symbols.filter_map { |symbol| scan(symbol) }
+    end
+
+    private
+
+    def scan(symbol)
+      setup = Analyzer.new(symbol, client: @client).call
+      unless setup
+        Rails.logger.debug { "[Crypto] no qualifying setup for #{symbol}" }
+        return nil
+      end
+
+      status = @notify ? AlertDispatcher.dispatch(setup) : :skipped
+      Result.new(symbol: symbol, setup: setup, status: status)
+    rescue StandardError => e
+      Rails.logger.error("[Crypto] scan failed for #{symbol}: #{e.class} - #{e.message}")
+      Rails.logger.error(e.backtrace.first(5).join("\n"))
+      nil
+    end
+  end
+end

--- a/app/services/crypto/series.rb
+++ b/app/services/crypto/series.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module Crypto
+  # An ordered, in-memory run of {Crypto::Candle} for one symbol/timeframe,
+  # plus the handful of measurements the SMC layer needs from raw price.
+  #
+  # Oldest candle first, newest last — every index in this namespace follows
+  # that convention, and the SMC detectors rely on it.
+  class Series
+    include Enumerable
+
+    attr_reader :symbol, :timeframe, :candles
+
+    def initialize(symbol:, timeframe:, candles: [])
+      @symbol    = symbol
+      @timeframe = timeframe
+      @candles   = candles
+    end
+
+    def self.from_binance(symbol:, timeframe:, rows:)
+      new(symbol: symbol, timeframe: timeframe, candles: rows.map { |row| Candle.from_binance(row) })
+    end
+
+    def each(&) = candles.each(&)
+    delegate :size, to: :candles
+    delegate :empty?, to: :candles
+    delegate :[], to: :candles
+    def last(count = nil) = count ? candles.last(count) : candles.last
+
+    def opens   = candles.map(&:open)
+    def highs   = candles.map(&:high)
+    def lows    = candles.map(&:low)
+    def closes  = candles.map(&:close)
+    def volumes = candles.map(&:volume)
+
+    def last_price = candles.last&.close
+    def last_time  = candles.last&.timestamp
+
+    # Average true range over the last `period` bars.
+    #
+    # A simple mean rather than Wilder's smoothing: everything downstream uses
+    # ATR as a distance yardstick (stop buffers, equal-high tolerance,
+    # displacement thresholds), where the two differ by less than the noise
+    # they are measuring.
+    #
+    # @return [Float] 0.0 when there is not enough history to measure
+    def atr(period = 14)
+      return 0.0 if candles.size < 2
+
+      trs = true_ranges.last(period)
+      return 0.0 if trs.empty?
+
+      trs.sum / trs.size
+    end
+
+    def ema(period)
+      values = closes
+      return [] if values.size < period
+
+      k = 2.0 / (period + 1)
+      seed = values.first(period).sum / period.to_f
+      out = [seed]
+      values.drop(period).each { |price| out << (((price - out.last) * k) + out.last) }
+      out
+    end
+
+    # Fractal pivot highs: bar `i` is a swing high when its high is the
+    # highest across `strength` bars either side.
+    #
+    # `confirmed_at` is the bar by which the pivot is *knowable* — a pivot at
+    # index i cannot be traded until i + strength has printed. Structure
+    # detection walks bars in order and must not use a pivot before then, or
+    # it reads the future.
+    #
+    # @return [Array<Hash>] {index:, price:, time:, confirmed_at:}
+    def swing_highs(strength: Config.swing_strength)
+      pivots(strength: strength, kind: :high)
+    end
+
+    def swing_lows(strength: Config.swing_strength)
+      pivots(strength: strength, kind: :low)
+    end
+
+    # @return [Float, nil] highest high of the last `count` bars
+    def highest(count = size)  = highs.last(count).max
+    def lowest(count = size)   = lows.last(count).min
+
+    private
+
+    def true_ranges
+      candles.each_cons(2).map do |prev, cur|
+        [cur.high - cur.low, (cur.high - prev.close).abs, (cur.low - prev.close).abs].max
+      end
+    end
+
+    def pivots(strength:, kind:)
+      return [] if candles.size < ((strength * 2) + 1)
+
+      series = kind == :high ? highs : lows
+      out = []
+
+      (strength...(candles.size - strength)).each do |i|
+        window = series[(i - strength)..(i + strength)]
+        pivot  = series[i]
+        extreme = kind == :high ? window.max : window.min
+        next unless pivot == extreme
+        # A flat cluster would otherwise report every bar in it as a pivot;
+        # keep the first and let the rest fall through.
+        next if window.count(extreme) > 1 && series[(i - strength)...i].include?(extreme)
+
+        out << { index: i, price: pivot, time: candles[i].timestamp, confirmed_at: i + strength }
+      end
+
+      out
+    end
+  end
+end

--- a/app/services/crypto/setup.rb
+++ b/app/services/crypto/setup.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Crypto
+  # A confirmed long or short setup, ready to be described to a human.
+  #
+  # Nothing here is persisted and nothing here places an order — a Setup is
+  # the scanner's entire output, produced only when {SetupDetector} passed
+  # every gate, and consumed by the formatter and the dispatcher.
+  class Setup
+    attr_reader :symbol, :direction, :score, :entry, :stop, :targets, :risk,
+                :risk_reward, :confluences, :poi, :context, :generated_at
+
+    def initialize(symbol:, direction:, score:, entry:, stop:, targets:, risk:,
+                   risk_reward:, confluences:, poi: nil, context: {})
+      @symbol       = symbol
+      @direction    = direction
+      @score        = score
+      @entry        = entry
+      @stop         = stop
+      @targets      = targets
+      @risk         = risk
+      @risk_reward  = risk_reward
+      @confluences  = confluences
+      @poi          = poi
+      @context      = context
+      @generated_at = Time.current
+    end
+
+    def long?  = direction == :long
+    def short? = direction == :short
+
+    def side = long? ? 'LONG' : 'SHORT'
+
+    def bias_direction = long? ? :bullish : :bearish
+
+    def target1 = targets.first
+    def target2 = targets[1]
+
+    # Grading is for the reader, not for the gate — anything that reaches a
+    # Setup already cleared the minimum score.
+    def grade
+      case score
+      when 85..Float::INFINITY then 'A+'
+      when 75...85 then 'A'
+      when 65...75 then 'B'
+      else 'C'
+      end
+    end
+
+    # Stable identity for deduplication: same symbol, same side, same POI
+    # band. Re-running the scan five minutes later on an unchanged chart
+    # produces the same key, and the dispatcher stays quiet.
+    def dedupe_key
+      zone = poi ? "#{round_key(poi.bottom)}-#{round_key(poi.top)}" : round_key(entry)
+      "#{symbol}:#{side}:#{zone}"
+    end
+
+    def to_h
+      {
+        symbol: symbol, side: side, score: score, grade: grade,
+        entry: entry, stop: stop, targets: targets,
+        risk: risk, risk_reward: risk_reward,
+        confluences: confluences.pluck(:label),
+        poi: poi&.to_h, context: context, generated_at: generated_at
+      }
+    end
+
+    private
+
+    # Bucketed to four significant decimals so a one-tick difference in the
+    # zone edge does not read as a new setup.
+    def round_key(value)
+      value.to_f.round(4)
+    end
+  end
+end

--- a/app/services/crypto/setup_detector.rb
+++ b/app/services/crypto/setup_detector.rb
@@ -1,0 +1,347 @@
+# frozen_string_literal: true
+
+module Crypto
+  # Top-down multi-timeframe engine: turns five {Smc::TimeframeReport}s into
+  # at most one {Setup}, or nil.
+  #
+  # The read is the classic ICT sequence, and each timeframe answers exactly
+  # one question:
+  #
+  #   1d / 4h   which way is the market drawing?          → direction
+  #   1h        is structure with us, and are we cheap?    → context
+  #   15m       is there a POI, and was liquidity taken?   → location
+  #   5m        has intent actually shown up?              → trigger
+  #
+  # Direction is decided by weighted vote rather than by hard gates so a
+  # genuine 4h reversal is not thrown away merely for disagreeing with a daily
+  # trend it has just begun to end. What is a hard gate: a 5m trigger must
+  # exist, both higher timeframes must not oppose the trade, and the levels
+  # have to produce an acceptable reward:risk. Everything else is scored, and
+  # a thin setup simply fails to reach the threshold.
+  class SetupDetector
+    # label => [weight, description]. The weights are what make the score
+    # meaningful, so they live in one table rather than scattered through the
+    # checks.
+    WEIGHTS = {
+      daily_alignment: 15,
+      h4_alignment: 15,
+      h1_alignment: 10,
+      h1_reversal: 6,
+      premium_discount: 10,
+      ote: 5,
+      m15_poi: 15,
+      m15_sweep: 12,
+      m5_trigger: 15,
+      m5_displacement: 5,
+      m5_imbalance: 5,
+      m5_confirmation: 4,
+      liquidity_target: 5
+    }.freeze
+
+    MAX_SCORE = WEIGHTS.values.sum.to_f
+
+    # Bars back within which a signal still counts as "now" on each timeframe.
+    H1_REVERSAL_LOOKBACK = 20
+    M15_SWEEP_LOOKBACK   = 12
+    M5_TRIGGER_LOOKBACK  = 12
+
+    # Buffer beyond the structural low/high, so a stop is not sitting exactly
+    # on the level everyone else's is.
+    STOP_BUFFER_ATR = 0.3
+
+    def self.call(...) = new(...).call
+
+    def initialize(symbol:, reports:, min_score: nil, min_risk_reward: nil)
+      @symbol          = symbol
+      @reports         = reports
+      @min_score       = min_score || Config.min_score
+      @min_risk_reward = min_risk_reward || Config.min_risk_reward
+    end
+
+    # @return [Crypto::Setup, nil]
+    def call
+      return nil unless complete_reports?
+
+      direction = candidate_direction
+      return nil if direction.nil?
+      return nil if higher_timeframes_oppose?(direction)
+
+      confluences = confluences_for(direction)
+      return nil unless triggered?(confluences)
+
+      score = score_for(confluences)
+      return nil if score < @min_score
+
+      levels = levels_for(direction)
+      return nil if levels.nil?
+
+      build_setup(direction, score, confluences, levels)
+    end
+
+    private
+
+    attr_reader :symbol, :reports
+
+    def daily = reports[Config::HTF_TIMEFRAMES[0]]
+    def h4    = reports[Config::HTF_TIMEFRAMES[1]]
+    def h1    = reports[Config::STRUCTURE_TIMEFRAME]
+    def m15   = reports[Config::SETUP_TIMEFRAME]
+    def m5    = reports[Config::EXECUTION_TIMEFRAME]
+
+    def complete_reports?
+      Config::TIMEFRAMES.all? { |tf| reports[tf].present? && reports[tf].series.size > 20 }
+    end
+
+    def price = m5.price
+
+    # --- direction ---------------------------------------------------------
+
+    # Weighted vote across the three context timeframes. A tie means the
+    # market has no agreed direction, and no direction means no trade.
+    def candidate_direction
+      votes = Hash.new(0)
+      { daily => 2, h4 => 2, h1 => 1 }.each do |report, weight|
+        votes[report.bias] += weight unless report.bias == :neutral
+      end
+
+      return nil if votes[:bullish] == votes[:bearish]
+
+      votes[:bullish] > votes[:bearish] ? :bullish : :bearish
+    end
+
+    # Fading both higher timeframes at once is not a setup, however good the
+    # lower-timeframe picture looks.
+    def higher_timeframes_oppose?(direction)
+      opposite = direction == :bullish ? :bearish : :bullish
+      daily.bias == opposite && h4.bias == opposite
+    end
+
+    # --- confluence --------------------------------------------------------
+
+    def confluences_for(direction)
+      checks(direction).filter_map do |key, (present, label)|
+        next unless present
+
+        { key: key, weight: WEIGHTS.fetch(key), label: label }
+      end
+    end
+
+    def checks(direction)
+      {
+        daily_alignment: [daily.bias == direction, "1d structure #{daily.bias}"],
+        h4_alignment: [h4.bias == direction, "4h structure #{h4.bias}"],
+        h1_alignment: [h1.bias == direction, "1h structure #{h1.bias}"],
+        h1_reversal: [h1_reversal?(direction), '1h CHoCH — early trend shift'],
+        premium_discount: [h1.premium_discount.favourable?(price, direction), premium_discount_label(direction)],
+        ote: [in_ote?(direction), 'Price in OTE (0.62–0.79 retracement)'],
+        m15_poi: [m15_poi(direction).present?, m15_poi_label(direction)],
+        m15_sweep: [m15_sweep(direction).present?, m15_sweep_label(direction)],
+        m5_trigger: [m5_trigger(direction).present?, m5_trigger_label(direction)],
+        m5_displacement: [m5.price_action.displacement?(direction), '5m displacement candle'],
+        m5_imbalance: [m5_imbalance?(direction), '5m fair value gap left behind'],
+        m5_confirmation: [m5_confirmation?(direction), '5m engulfing / rejection wick'],
+        liquidity_target: [liquidity_target(direction).present?, liquidity_target_label(direction)]
+      }
+    end
+
+    def triggered?(confluences)
+      confluences.any? { |c| c[:key] == :m5_trigger }
+    end
+
+    def score_for(confluences)
+      ((confluences.sum { |c| c[:weight] } / MAX_SCORE) * 100).round(1)
+    end
+
+    def h1_reversal?(direction)
+      h1.structure.recent_event(direction: direction, type: :choch, lookback: H1_REVERSAL_LOOKBACK).present?
+    end
+
+    def in_ote?(direction)
+      h1.premium_discount.in_ote?(price, direction) || m15.premium_discount.in_ote?(price, direction)
+    end
+
+    def m15_poi(direction)
+      @m15_poi ||= {}
+      @m15_poi[direction] ||= m15.active_poi(direction)
+    end
+
+    def m15_sweep(direction)
+      @m15_sweep ||= {}
+      @m15_sweep[direction] ||= m15.liquidity.recent_sweep(direction, lookback: M15_SWEEP_LOOKBACK)
+    end
+
+    def m5_trigger(direction)
+      @m5_trigger ||= {}
+      @m5_trigger[direction] ||= m5.structure.recent_event(direction: direction, lookback: M5_TRIGGER_LOOKBACK)
+    end
+
+    def m5_imbalance?(direction)
+      m5.fair_value_gaps.candidates(direction, price).any? { |zone| zone.index >= m5.series.size - 10 }
+    end
+
+    def m5_confirmation?(direction)
+      m5.price_action.engulfing?(direction) || m5.price_action.rejection?(direction)
+    end
+
+    # Where the move is drawn to: resting liquidity beyond the entry, on 15m
+    # first and 1h as the extended objective.
+    def liquidity_target(direction, report = m15, from = nil)
+      from ||= price
+      if direction == :bullish
+        report.liquidity.target_above(from) || report.structure.next_liquidity_above(from)
+      else
+        report.liquidity.target_below(from) || report.structure.next_liquidity_below(from)
+      end
+    end
+
+    # --- levels ------------------------------------------------------------
+
+    def levels_for(direction)
+      entry = price
+      stop  = stop_for(direction, entry)
+      return nil if stop.nil?
+
+      risk = (entry - stop).abs
+      return nil unless risk.positive?
+      return nil if risk > (m15.atr * Config.max_stop_atr_multiple)
+
+      targets = targets_for(direction, entry, risk)
+      rr = ((targets.first - entry).abs / risk).round(2)
+      return nil if rr < @min_risk_reward
+
+      { entry: entry, stop: stop, targets: targets, risk: risk, risk_reward: rr }
+    end
+
+    # The stop sits beyond whichever structure is protecting the trade: the
+    # POI that price reacted from, the low that was swept, or the last 5m
+    # swing — whichever is furthest, plus a buffer.
+    def stop_for(direction, entry)
+      buffer = m5.atr * STOP_BUFFER_ATR
+      anchors = stop_anchors(direction)
+      return nil if anchors.empty?
+
+      if direction == :bullish
+        level = anchors.min - buffer
+        level < entry ? level : nil
+      else
+        level = anchors.max + buffer
+        level > entry ? level : nil
+      end
+    end
+
+    def stop_anchors(direction)
+      poi = m15_poi(direction)
+      sweep = m15_sweep(direction)
+      swing = direction == :bullish ? recent_swing_low : recent_swing_high
+
+      [
+        poi && (direction == :bullish ? poi.bottom : poi.top),
+        sweep&.level,
+        swing
+      ].compact
+    end
+
+    def recent_swing_low(lookback: 12)
+      m5.series.candles.last(lookback).map(&:low).min
+    end
+
+    def recent_swing_high(lookback: 12)
+      m5.series.candles.last(lookback).map(&:high).max
+    end
+
+    # TP1 is the nearest 15m liquidity pool, TP2 the 1h one. Where the pool is
+    # too close to be worth the risk, an R-multiple stands in — the point of
+    # the target is to be reachable, and a pool half an R away is not a target
+    # so much as noise.
+    def targets_for(direction, entry, risk)
+      sign = direction == :bullish ? 1 : -1
+
+      tp1 = pick_target(liquidity_target(direction, m15, entry), entry + (sign * risk * 1.5), direction)
+      tp2 = pick_target(liquidity_target(direction, h1, entry), entry + (sign * risk * 3.0), direction)
+
+      # TP2 has to clear TP1, and an R-multiple measured from *entry* does not
+      # guarantee that: where the 15m pool already sits beyond 3R, the 1h
+      # fallback lands between entry and TP1 and the alert reads with its
+      # targets inverted. Measure the floor from TP1 instead.
+      tp2 = pick_target(tp2, tp1 + (sign * risk * 0.75), direction)
+
+      [tp1.round(6), tp2.round(6)]
+    end
+
+    # The further of `candidate` and `floor`, in the trade's direction.
+    def pick_target(candidate, floor, direction)
+      return floor if candidate.nil?
+
+      direction == :bullish ? [candidate, floor].max : [candidate, floor].min
+    end
+
+    # --- assembly ----------------------------------------------------------
+
+    def build_setup(direction, score, confluences, levels)
+      Setup.new(
+        symbol: symbol,
+        direction: direction == :bullish ? :long : :short,
+        score: score,
+        entry: levels[:entry],
+        stop: levels[:stop],
+        targets: levels[:targets],
+        risk: levels[:risk],
+        risk_reward: levels[:risk_reward],
+        confluences: confluences,
+        poi: m15_poi(direction),
+        context: context_for(direction)
+      )
+    end
+
+    def context_for(direction)
+      {
+        bias: { '1d' => daily.bias, '4h' => h4.bias, '1h' => h1.bias, '15m' => m15.bias, '5m' => m5.bias },
+        range_zone: h1.premium_discount.zone(price),
+        trigger: m5_trigger(direction)&.to_s,
+        sweep: m15_sweep(direction)&.level,
+        atr: { '15m' => m15.atr, '5m' => m5.atr }
+      }
+    end
+
+    def premium_discount_label(direction)
+      zone = h1.premium_discount.zone(price)
+      side = direction == :bullish ? 'discount' : 'premium'
+      "Price in #{zone || side} of the 1h dealing range"
+    end
+
+    def m15_poi_label(direction)
+      poi = m15_poi(direction)
+      return '15m point of interest' if poi.nil?
+
+      state = poi.fresh? ? 'unmitigated' : 'retested'
+      "15m #{state} #{poi.kind == :fvg ? 'FVG' : 'order block'} " \
+        "#{format_price(poi.bottom)}–#{format_price(poi.top)}"
+    end
+
+    def m15_sweep_label(direction)
+      sweep = m15_sweep(direction)
+      return '15m liquidity sweep' if sweep.nil?
+
+      side = direction == :bullish ? 'sell-side' : 'buy-side'
+      "15m #{side} liquidity swept at #{format_price(sweep.level)}"
+    end
+
+    def m5_trigger_label(direction)
+      event = m5_trigger(direction)
+      return '5m structure shift' if event.nil?
+
+      "5m #{event.type.to_s.upcase} through #{format_price(event.level)}"
+    end
+
+    def liquidity_target_label(direction)
+      target = liquidity_target(direction)
+      return 'Liquidity resting beyond entry' if target.nil?
+
+      "Liquidity resting at #{format_price(target)}"
+    end
+
+    def format_price(value)
+      Formatting.price(value)
+    end
+  end
+end

--- a/app/services/crypto/setup_formatter.rb
+++ b/app/services/crypto/setup_formatter.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Crypto
+  # Renders a {Setup} as the Telegram message a human reads on their phone.
+  #
+  # Plain text with emoji rather than Markdown or HTML: a symbol or a level
+  # never needs escaping, so a stray underscore in a future pair name cannot
+  # make Telegram reject the whole message. The order is the order the trade
+  # is taken in — what, where, how much risk, then why.
+  class SetupFormatter
+    def self.call(...) = new(...).call
+
+    def initialize(setup)
+      @setup = setup
+    end
+
+    def call
+      [header, levels, context, confluence, footer].compact.join("\n\n")
+    end
+
+    private
+
+    attr_reader :setup
+
+    def header
+      arrow = setup.long? ? '🟢 LONG' : '🔴 SHORT'
+      "#{arrow}  #{setup.symbol}\n" \
+        "SMC / ICT setup · grade #{setup.grade} · score #{setup.score}/100"
+    end
+
+    def levels
+      lines = [
+        "🎯 Entry   #{fmt(setup.entry)}",
+        "🛑 Stop    #{fmt(setup.stop)}   (#{Formatting.move_percent(setup.entry, setup.stop)})",
+        "✅ TP1     #{fmt(setup.target1)}   (#{Formatting.move_percent(setup.entry, setup.target1)})"
+      ]
+      lines << "✅ TP2     #{fmt(setup.target2)}   (#{Formatting.move_percent(setup.entry, setup.target2)})" if setup.target2
+      lines << "⚖️ Risk    #{fmt(setup.risk)} per unit · R:R #{setup.risk_reward}"
+      lines.join("\n")
+    end
+
+    def context
+      bias = setup.context[:bias] || {}
+      order = %w[1d 4h 1h 15m 5m]
+      line = order.filter_map { |tf| "#{tf} #{arrow_for(bias[tf])}" if bias.key?(tf) }.join('  ')
+      return nil if line.blank?
+
+      "🧭 Bias\n#{line}\nRange: #{setup.context[:range_zone] || 'n/a'}"
+    end
+
+    def confluence
+      return nil if setup.confluences.blank?
+
+      body = setup.confluences.map { |c| "• #{c[:label]}" }.join("\n")
+      "📋 Confluence\n#{body}"
+    end
+
+    def footer
+      "🕒 #{setup.generated_at.in_time_zone('Asia/Kolkata').strftime('%d %b %Y %H:%M %Z')}\n" \
+        'Analysis only — no order was placed.'
+    end
+
+    def arrow_for(bias)
+      case bias
+      when :bullish then '↑'
+      when :bearish then '↓'
+      else '→'
+      end
+    end
+
+    # Named `fmt` rather than `p`, which would shadow Kernel#p.
+    def fmt(value) = Formatting.price(value)
+  end
+end

--- a/app/services/crypto/smc/fair_value_gaps.rb
+++ b/app/services/crypto/smc/fair_value_gaps.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Crypto
+  module Smc
+    # Fair value gaps (ICT imbalances): a three-candle formation where the
+    # middle candle moved fast enough that the wicks either side never
+    # overlapped, leaving a band of price that was only ever traded in one
+    # direction.
+    #
+    #   bullish  low[i] > high[i-2]   → gap between high[i-2] and low[i]
+    #   bearish  high[i] < low[i-2]   → gap between high[i] and low[i-2]
+    #
+    # Tiny gaps are noise on any timeframe, so a gap must be worth at least
+    # MIN_ATR_FRACTION of ATR to be recorded.
+    class FairValueGaps
+      MIN_ATR_FRACTION = 0.12
+      MAX_ZONES = 8
+
+      attr_reader :series, :zones
+
+      def initialize(series)
+        @series = series
+        @atr    = series.atr
+        @zones  = detect
+      end
+
+      def bullish = zones.select(&:bullish?)
+      def bearish = zones.select(&:bearish?)
+
+      def for(direction)
+        direction == :bullish ? bullish : bearish
+      end
+
+      # Unfilled gaps in `direction`, nearest to price first. An unfilled gap
+      # is the one still holding an imbalance, and therefore the one price has
+      # a reason to revisit.
+      def candidates(direction, price = series.last_price)
+        self.for(direction).reject(&:invalidated?).sort_by { |z| z.distance_from(price) }
+      end
+
+      private
+
+      def detect
+        found = []
+
+        (2...series.size).each do |i|
+          prev2 = series[i - 2]
+          cur   = series[i]
+
+          if cur.low > prev2.high
+            found << gap(:bullish, top: cur.low, bottom: prev2.high, index: i, time: cur.timestamp)
+          elsif cur.high < prev2.low
+            found << gap(:bearish, top: prev2.low, bottom: cur.high, index: i, time: cur.timestamp)
+          end
+        end
+
+        found = found.compact
+        found.each { |zone| mark_state(zone) }
+        found.last(MAX_ZONES)
+      end
+
+      def gap(direction, top:, bottom:, index:, time:)
+        height = top - bottom
+        return nil if @atr.positive? && height < (@atr * MIN_ATR_FRACTION)
+        return nil unless height.positive?
+
+        Zone.new(kind: :fvg, direction: direction, top: top, bottom: bottom, index: index, time: time)
+      end
+
+      # A gap is tapped once price trades back into it and invalidated
+      # ("filled") once price has traded all the way through — at that point
+      # the imbalance it represented no longer exists.
+      def mark_state(zone)
+        series.candles.each_with_index do |candle, idx|
+          next if idx <= zone.index
+
+          zone.tapped = true if candle.low <= zone.top && candle.high >= zone.bottom
+
+          if zone.bullish?
+            zone.invalidated = true if candle.low <= zone.bottom
+          elsif candle.high >= zone.top
+            zone.invalidated = true
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/crypto/smc/liquidity.rb
+++ b/app/services/crypto/smc/liquidity.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Crypto
+  module Smc
+    # Liquidity: where stops are resting, and when they have just been taken.
+    #
+    # Equal highs and equal lows are pools — obvious levels a crowd puts stops
+    # behind. A **sweep** is the moment one is raided: price wicks through the
+    # level and closes back inside. That close is what separates a sweep from a
+    # break; {Structure} handles the latter and reads the same bar as
+    # continuation, so the close test has to be strict in both places or the
+    # two detectors will contradict each other on the same candle.
+    #
+    # Directional convention, which is the opposite of what the wick looks
+    # like: taking out highs (buy-side liquidity) and rejecting is *bearish*;
+    # taking out lows (sell-side liquidity) and rejecting is *bullish*.
+    class Liquidity
+      Sweep = Struct.new(:direction, :level, :index, :time, :penetration, keyword_init: true) do
+        def bullish? = direction == :bullish
+        def bearish? = direction == :bearish
+      end
+
+      # `strength` is how many pivots formed the pool — two equal highs are a
+      # pool, five are a magnet. Not named `count`: that would shadow
+      # Struct#count and read as an element count rather than a touch count.
+      Pool = Struct.new(:side, :price, :strength, :time, keyword_init: true)
+
+      # Two pivots within this fraction of ATR count as "equal".
+      EQUALITY_ATR_FRACTION = 0.12
+
+      attr_reader :series, :structure, :sweeps, :pools
+
+      def initialize(series, structure)
+        @series    = series
+        @structure = structure
+        @atr       = series.atr
+        @sweeps    = detect_sweeps
+        @pools     = detect_pools
+      end
+
+      # Most recent sweep in `direction` inside the last `lookback` bars.
+      #
+      # A sweep from fifty bars ago is history; the setup engine only cares
+      # about one price is still reacting to.
+      def recent_sweep(direction, lookback: 20)
+        cutoff = series.size - lookback
+        sweeps.reverse_each.find { |s| s.direction == direction && s.index >= cutoff }
+      end
+
+      def equal_highs = pools.select { |p| p.side == :high }
+      def equal_lows  = pools.select { |p| p.side == :low }
+
+      # Nearest untouched pool above/below price — the natural draw for a move,
+      # and therefore the target the setup engine reaches for first.
+      def target_above(price = series.last_price)
+        equal_highs.map(&:price).select { |p| p > price }.min
+      end
+
+      def target_below(price = series.last_price)
+        equal_lows.map(&:price).select { |p| p < price }.max
+      end
+
+      private
+
+      def detect_sweeps
+        found = []
+        seen = Set.new
+
+        series.candles.each_with_index do |candle, idx|
+          swept_high = raided(structure.swing_highs, idx) { |level| candle.high > level && candle.close < level }
+          if swept_high && seen.add?([:bearish, swept_high])
+            found << Sweep.new(direction: :bearish, level: swept_high, index: idx,
+                               time: candle.timestamp, penetration: candle.high - swept_high)
+          end
+
+          swept_low = raided(structure.swing_lows, idx) { |level| candle.low < level && candle.close > level }
+          next unless swept_low && seen.add?([:bullish, swept_low])
+
+          found << Sweep.new(direction: :bullish, level: swept_low, index: idx,
+                             time: candle.timestamp, penetration: swept_low - candle.low)
+        end
+
+        found
+      end
+
+      # Tests bar `idx` against the *most recent* pivot that was knowable
+      # before it — not every pivot in history.
+      #
+      # Checking them all was the first version and it was useless: in any
+      # oscillating market almost every bar wicks past one of the dozens of
+      # old pivots lying around and closes back inside, which reported a sweep
+      # on half the candles in the series and made the signal worth nothing.
+      # A sweep is a raid on the level traders are actually watching, which is
+      # the latest one.
+      def raided(pivots, idx)
+        pivot = pivots.reverse_each.find { |p| p[:confirmed_at] <= idx && p[:index] < idx }
+        return nil if pivot.nil?
+
+        yield(pivot[:price]) ? pivot[:price] : nil
+      end
+
+      def detect_pools
+        cluster(structure.swing_highs, :high) + cluster(structure.swing_lows, :low)
+      end
+
+      def cluster(pivots, side)
+        tolerance = equality_tolerance
+        return pivots.map { |pivot| pool_from([pivot], side) } if tolerance.nil?
+
+        bucket_by_price(pivots, tolerance).map { |bucket| pool_from(bucket, side) }
+      end
+
+      # Without an ATR to scale against there is no meaningful notion of
+      # "equal", so every pivot stands alone.
+      def equality_tolerance
+        @atr.positive? ? @atr * EQUALITY_ATR_FRACTION : nil
+      end
+
+      def bucket_by_price(pivots, tolerance)
+        pivots.sort_by { |p| p[:price] }.each_with_object([]) do |pivot, buckets|
+          bucket = buckets.find { |b| (b.first[:price] - pivot[:price]).abs <= tolerance }
+          bucket ? bucket << pivot : buckets << [pivot]
+        end
+      end
+
+      # The pool sits at the extreme of its bucket — that is the level the
+      # stops are actually behind.
+      def pool_from(bucket, side)
+        prices = bucket.pluck(:price)
+
+        Pool.new(side: side,
+                 price: side == :high ? prices.max : prices.min,
+                 strength: bucket.size,
+                 time: bucket.max_by { |p| p[:index] }[:time])
+      end
+    end
+  end
+end

--- a/app/services/crypto/smc/order_blocks.rb
+++ b/app/services/crypto/smc/order_blocks.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Crypto
+  module Smc
+    # Order blocks: the last opposing candle before the impulse that broke
+    # structure.
+    #
+    # The break is what qualifies the candle. Any down candle can be pointed at
+    # after the fact; only one that was immediately followed by displacement
+    # through a swing high marks where size actually entered. So detection
+    # starts from {Structure}'s events and walks *backwards* into the impulse,
+    # rather than scanning for pretty candles and hoping.
+    class OrderBlocks
+      # How far back from a break to look for the originating candle. An
+      # impulse that took more bars than this is not an impulse.
+      IMPULSE_LOOKBACK = 12
+
+      # Keep the most recent blocks only — a two-day-old 5m order block is
+      # archaeology, not a level.
+      MAX_ZONES = 6
+
+      attr_reader :series, :structure, :zones
+
+      def initialize(series, structure)
+        @series    = series
+        @structure = structure
+        @zones     = detect
+      end
+
+      def bullish = zones.select(&:bullish?)
+      def bearish = zones.select(&:bearish?)
+
+      def for(direction)
+        direction == :bullish ? bullish : bearish
+      end
+
+      # Valid zones in `direction`, nearest to price first.
+      def candidates(direction, price = series.last_price)
+        self.for(direction).select(&:valid?).sort_by { |z| z.distance_from(price) }
+      end
+
+      private
+
+      def detect
+        found = structure.events.filter_map { |event| build_zone(event) }
+        found = dedupe(found)
+        found.each { |zone| mark_state(zone) }
+        found.last(MAX_ZONES)
+      end
+
+      def build_zone(event)
+        origin = origin_candle(event)
+        return nil unless origin
+
+        Zone.new(kind: :order_block, direction: event.direction,
+                 top: origin[:candle].high, bottom: origin[:candle].low,
+                 index: origin[:index], time: origin[:candle].timestamp)
+      end
+
+      # The last candle against the break's direction, immediately preceding
+      # the impulse leg.
+      def origin_candle(event)
+        start_idx = [event.index - 1, 0].max
+        floor_idx = [event.index - IMPULSE_LOOKBACK, 0].max
+
+        start_idx.downto(floor_idx) do |i|
+          candle = series[i]
+          next unless candle
+          return { candle: candle, index: i } if event.bullish? ? candle.bearish? : candle.bullish?
+        end
+
+        nil
+      end
+
+      # Consecutive events often resolve to the same origin candle; one zone
+      # per candle is enough.
+      def dedupe(found)
+        found.uniq { |zone| [zone.index, zone.direction] }
+      end
+
+      # Walks everything that printed after the zone formed and records
+      # whether price has returned to it (tapped) or run through it
+      # (invalidated). Invalidation is judged on closes; a wick through an
+      # order block is exactly the sweep the block is there to produce.
+      def mark_state(zone)
+        series.candles.each_with_index do |candle, idx|
+          next if idx <= zone.index + 1
+
+          zone.tapped = true if candle.low <= zone.top && candle.high >= zone.bottom
+
+          if zone.bullish?
+            zone.invalidated = true if candle.close < zone.bottom
+          elsif candle.close > zone.top
+            zone.invalidated = true
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/crypto/smc/premium_discount.rb
+++ b/app/services/crypto/smc/premium_discount.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Crypto
+  module Smc
+    # Premium/discount pricing over the current dealing range, plus the
+    # optimal-trade-entry band.
+    #
+    # The rule this encodes is the reason most of ICT's entry criteria exist:
+    # buy in discount, sell in premium. A long taken at the top of the range is
+    # the same idea as a long taken at the bottom, with the risk inverted.
+    #
+    # OTE is the 0.618–0.79 retracement of the leg — measured from the end of
+    # the move, so a bullish leg's OTE sits in the lower half of the range.
+    class PremiumDiscount
+      OTE_START = 0.618
+      OTE_END   = 0.79
+      # Prices this close to the 50% mark are equilibrium rather than either
+      # side of it — a razor-thin boundary would flip on a single tick.
+      EQUILIBRIUM_BAND = 0.05
+
+      attr_reader :high, :low
+
+      def initialize(dealing_range)
+        @high = dealing_range&.dig(:high)
+        @low  = dealing_range&.dig(:low)
+      end
+
+      def valid?
+        high.present? && low.present? && high > low
+      end
+
+      def range = valid? ? high - low : 0.0
+      def equilibrium = valid? ? (high + low) / 2.0 : nil
+
+      # Where price sits in the range, 0.0 at the low and 1.0 at the high.
+      def position(price)
+        return nil unless valid?
+
+        ((price - low) / range).clamp(-1.0, 2.0)
+      end
+
+      # @return [Symbol, nil] :discount, :premium or :equilibrium
+      def zone(price)
+        pos = position(price)
+        return nil if pos.nil?
+
+        if (pos - 0.5).abs <= EQUILIBRIUM_BAND then :equilibrium
+        elsif pos < 0.5 then :discount
+        else
+          :premium
+        end
+      end
+
+      # Is price on the correct side of equilibrium for the intended trade?
+      # Equilibrium itself is allowed — it is neutral, not wrong.
+      def favourable?(price, direction)
+        z = zone(price)
+        return false if z.nil?
+        return true if z == :equilibrium
+
+        z == (direction == :bullish ? :discount : :premium)
+      end
+
+      # The 0.618–0.79 retracement band for a trade in `direction`.
+      #
+      # @return [Hash, nil] {top:, bottom:}
+      def ote(direction)
+        return nil unless valid?
+
+        if direction == :bullish
+          { top: high - (range * OTE_START), bottom: high - (range * OTE_END) }
+        else
+          { top: low + (range * OTE_END), bottom: low + (range * OTE_START) }
+        end
+      end
+
+      def in_ote?(price, direction)
+        band = ote(direction)
+        return false if band.nil?
+
+        price >= band[:bottom] && price <= band[:top]
+      end
+
+      def to_h
+        { high: high, low: low, equilibrium: equilibrium }
+      end
+    end
+  end
+end

--- a/app/services/crypto/smc/price_action.rb
+++ b/app/services/crypto/smc/price_action.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Crypto
+  module Smc
+    # Raw candle behaviour: displacement, engulfing and rejection wicks.
+    #
+    # These are the confirmations, never the reason for a trade. The setup
+    # engine weights them lightly for exactly that reason — an engulfing candle
+    # inside a range is a coin flip, while the same candle out of a swept
+    # discount order block is the entry.
+    #
+    # Every threshold is ATR-relative so one set of numbers works on a $4,000
+    # ETH candle and a $150 SOL candle.
+    class PriceAction
+      DISPLACEMENT_ATR_MULTIPLE = 1.15
+      DISPLACEMENT_BODY_RATIO   = 0.55
+      ENGULFING_BODY_RATIO      = 0.5
+      REJECTION_WICK_RATIO      = 0.55
+
+      attr_reader :series
+
+      def initialize(series)
+        @series = series
+        @atr    = series.atr
+      end
+
+      # A candle whose body is large relative to recent range — the footprint
+      # of an aggressive market participant rather than a drift.
+      def displacement(direction, lookback: 5)
+        recent(lookback).reverse_each.find do |candle|
+          next false unless directional?(candle, direction)
+
+          candle.body >= (@atr * DISPLACEMENT_ATR_MULTIPLE) && candle.body_ratio >= DISPLACEMENT_BODY_RATIO
+        end
+      end
+
+      def displacement?(direction, lookback: 5) = displacement(direction, lookback: lookback).present?
+
+      # Engulfing: the current body fully covers the previous body against the
+      # previous candle's direction.
+      def engulfing(direction, lookback: 3)
+        pairs(lookback).reverse_each do |prev, cur|
+          next unless directional?(cur, direction)
+          next unless prev.body.positive? && cur.body >= prev.body
+          next unless cur.body_ratio >= ENGULFING_BODY_RATIO
+
+          covered = if direction == :bullish
+                      cur.close >= [prev.open, prev.close].max && cur.open <= [prev.open, prev.close].min
+                    else
+                      cur.close <= [prev.open, prev.close].min && cur.open >= [prev.open, prev.close].max
+                    end
+          return cur if covered
+        end
+        nil
+      end
+
+      def engulfing?(direction, lookback: 3) = engulfing(direction, lookback: lookback).present?
+
+      # A long wick against the intended direction: price probed and was
+      # refused.
+      def rejection(direction, lookback: 3)
+        recent(lookback).reverse_each.find do |candle|
+          next false unless candle.range.positive?
+
+          wick = direction == :bullish ? candle.lower_wick : candle.upper_wick
+          wick / candle.range >= REJECTION_WICK_RATIO
+        end
+      end
+
+      def rejection?(direction, lookback: 3) = rejection(direction, lookback: lookback).present?
+
+      private
+
+      def recent(count) = series.candles.last(count)
+
+      def pairs(count) = series.candles.last(count + 1).each_cons(2).to_a
+
+      def directional?(candle, direction)
+        direction == :bullish ? candle.bullish? : candle.bearish?
+      end
+    end
+  end
+end

--- a/app/services/crypto/smc/structure.rb
+++ b/app/services/crypto/smc/structure.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module Crypto
+  module Smc
+    # Market structure: the sequence of BOS and CHoCH events that defines
+    # directional bias on a timeframe.
+    #
+    #   BOS   (Break of Structure)     — price closes beyond the most recent
+    #                                    swing *in the direction it was already
+    #                                    trending*. Continuation.
+    #   CHoCH (Change of Character)    — the same break, but against the
+    #                                    prevailing trend. The first warning
+    #                                    that the leg is over.
+    #
+    # Two rules make the output tradable rather than merely plausible:
+    #
+    # 1. A break is confirmed on a **close**, not a wick. A wick through a
+    #    swing high that closes back below is a liquidity sweep — the opposite
+    #    signal — and {Liquidity} is what reads it.
+    # 2. A pivot is only usable from `confirmed_at` onward. A fractal at bar i
+    #    is not knowable until i + strength has printed, so walking bars with
+    #    the full pivot list in hand would break structure against levels the
+    #    market had not yet formed and report signals that never existed live.
+    class Structure
+      Event = Struct.new(:type, :direction, :level, :index, :time, keyword_init: true) do
+        def bullish? = direction == :bullish
+        def bearish? = direction == :bearish
+        def choch?   = type == :choch
+        def bos?     = type == :bos
+        def to_s     = "#{type.to_s.upcase} #{direction}"
+      end
+
+      attr_reader :series, :strength, :events, :swing_highs, :swing_lows
+
+      def initialize(series, strength: Config.swing_strength)
+        @series      = series
+        @strength    = strength
+        @swing_highs = series.swing_highs(strength: strength)
+        @swing_lows  = series.swing_lows(strength: strength)
+        @events      = detect_events
+      end
+
+      # @return [Symbol] :bullish, :bearish or :neutral
+      def trend
+        last_event&.direction || :neutral
+      end
+
+      def last_event = events.last
+
+      # Most recent event in a given direction, within `lookback` bars of the
+      # end of the series. Used to ask "did 5m just shift up?" without
+      # accepting a shift from two sessions ago.
+      def recent_event(direction: nil, type: nil, lookback: 30)
+        cutoff = series.size - lookback
+        events.reverse_each.find do |event|
+          event.index >= cutoff &&
+            (direction.nil? || event.direction == direction) &&
+            (type.nil? || event.type == type)
+        end
+      end
+
+      def bullish? = trend == :bullish
+      def bearish? = trend == :bearish
+
+      # The swing high above / swing low below current price — where resting
+      # liquidity sits, and therefore where a move is drawn to.
+      def next_liquidity_above(price = series.last_price)
+        swing_highs.pluck(:price).select { |p| p > price }.min
+      end
+
+      def next_liquidity_below(price = series.last_price)
+        swing_lows.pluck(:price).select { |p| p < price }.max
+      end
+
+      # The high/low pair defining the current leg, for premium/discount work.
+      # Falls back to the series extremes when there are too few pivots.
+      #
+      # @return [Hash, nil] {high:, low:, high_time:, low_time:}
+      def dealing_range(lookback: 60)
+        recent = ->(pivots) { pivots.select { |p| p[:index] >= series.size - lookback } }
+        highs = recent.call(swing_highs)
+        lows  = recent.call(swing_lows)
+
+        high = highs.max_by { |p| p[:price] }
+        low  = lows.min_by { |p| p[:price] }
+        return fallback_range(lookback) if high.nil? || low.nil?
+
+        { high: high[:price], low: low[:price], high_time: high[:time], low_time: low[:time] }
+      end
+
+      private
+
+      def fallback_range(lookback)
+        window = series.candles.last(lookback)
+        return nil if window.empty?
+
+        { high: window.map(&:high).max, low: window.map(&:low).min, high_time: nil, low_time: nil }
+      end
+
+      # Walks the series once, holding the most recent *confirmed and unbroken*
+      # pivot on each side, and emits an event whenever a close clears one.
+      def detect_events
+        return [] if series.size < ((strength * 2) + 2)
+
+        @detected = []
+        @running_trend = :neutral
+        @active = { high: nil, low: nil }
+        @by_confirmation = {
+          high: swing_highs.group_by { |s| s[:confirmed_at] },
+          low: swing_lows.group_by { |s| s[:confirmed_at] }
+        }
+
+        series.candles.each_with_index { |candle, idx| step(candle, idx) }
+        @detected
+      end
+
+      def step(candle, idx)
+        activate_pivots(idx)
+        broke?(candle, idx, :high) || broke?(candle, idx, :low)
+      end
+
+      # A pivot becomes usable at its confirmation bar, and the latest one on
+      # each side is the level structure is measured against.
+      def activate_pivots(idx)
+        %i[high low].each do |side|
+          confirmed = @by_confirmation[side][idx]
+          @active[side] = confirmed.max_by { |s| s[:index] } if confirmed
+        end
+      end
+
+      def broke?(candle, idx, side)
+        pivot = @active[side]
+        return false if pivot.nil?
+        return false unless side == :high ? candle.close > pivot[:price] : candle.close < pivot[:price]
+
+        record(side == :high ? :bullish : :bearish, pivot[:price], idx, candle.timestamp)
+        @active[side] = nil
+        true
+      end
+
+      def record(direction, level, index, time)
+        # The first break of a series has no prior trend to contradict, so it
+        # is a BOS rather than a change of character.
+        type = @running_trend != :neutral && @running_trend != direction ? :choch : :bos
+        @detected << Event.new(type: type, direction: direction, level: level, index: index, time: time)
+        @running_trend = direction
+      end
+    end
+  end
+end

--- a/app/services/crypto/smc/timeframe_report.rb
+++ b/app/services/crypto/smc/timeframe_report.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Crypto
+  module Smc
+    # Everything the SMC layer knows about one symbol on one timeframe.
+    #
+    # Built once per timeframe per scan and passed around read-only, so the
+    # setup engine never re-derives structure and every check below is asking
+    # the same set of swings the same question.
+    class TimeframeReport
+      attr_reader :timeframe, :series, :structure, :order_blocks, :fair_value_gaps,
+                  :liquidity, :premium_discount, :price_action
+
+      def initialize(series)
+        @timeframe        = series.timeframe
+        @series           = series
+        @structure        = Structure.new(series)
+        @order_blocks     = OrderBlocks.new(series, @structure)
+        @fair_value_gaps  = FairValueGaps.new(series)
+        @liquidity        = Liquidity.new(series, @structure)
+        @premium_discount = PremiumDiscount.new(@structure.dealing_range)
+        @price_action     = PriceAction.new(series)
+      end
+
+      def price = series.last_price
+      delegate :atr, to: :series
+      def bias = structure.trend
+
+      def bullish? = bias == :bullish
+      def bearish? = bias == :bearish
+
+      # Points of interest in `direction` that price is currently sitting in
+      # or approaching — order blocks first, then unfilled gaps.
+      #
+      # An already-tapped order block is kept but ranked behind a fresh one:
+      # it is weaker, not dead, and on a 15m chart discarding it would often
+      # leave no POI at all.
+      def points_of_interest(direction)
+        blocks = order_blocks.candidates(direction, price)
+        gaps   = fair_value_gaps.candidates(direction, price)
+        (blocks + gaps).sort_by { |zone| [zone.fresh? ? 0 : 1, zone.distance_from(price)] }
+      end
+
+      # The nearest POI price is actually interacting with, if any.
+      def active_poi(direction, atr_multiple: 0.75)
+        points_of_interest(direction).find { |zone| zone.near?(price, atr, multiple: atr_multiple) }
+      end
+
+      def summary
+        {
+          timeframe: timeframe,
+          bias: bias,
+          last_event: structure.last_event&.to_s,
+          price: price,
+          atr: atr.round(4),
+          zone: premium_discount.zone(price),
+          order_blocks: order_blocks.zones.size,
+          fair_value_gaps: fair_value_gaps.zones.size
+        }
+      end
+    end
+  end
+end

--- a/app/services/crypto/smc/zone.rb
+++ b/app/services/crypto/smc/zone.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Crypto
+  module Smc
+    # A price band that acts as a point of interest — an order block, a fair
+    # value gap, or anything else the detectors want to hand to the setup
+    # engine in a uniform shape.
+    #
+    # `tapped` and `invalidated` are tracked separately on purpose. A zone
+    # price has merely touched is still in play (that touch is the entry); a
+    # zone price has *closed through* is gone, and treating the two the same
+    # is how a scanner ends up buying into a broken level.
+    class Zone
+      attr_reader :kind, :direction, :top, :bottom, :index, :time
+      attr_accessor :tapped, :invalidated
+
+      def initialize(kind:, direction:, top:, bottom:, index:, time:)
+        @kind        = kind
+        @direction   = direction
+        @top         = [top, bottom].max.to_f
+        @bottom      = [top, bottom].min.to_f
+        @index       = index
+        @time        = time
+        @tapped      = false
+        @invalidated = false
+      end
+
+      def tapped?      = tapped
+      def invalidated? = invalidated
+      def fresh?       = !tapped && !invalidated
+      def valid?       = !invalidated
+
+      def bullish? = direction == :bullish
+      def bearish? = direction == :bearish
+
+      def height   = top - bottom
+      def midpoint = (top + bottom) / 2.0
+
+      def contains?(price) = price >= bottom && price <= top
+
+      # Distance from price to the near edge of the zone, 0 when inside.
+      def distance_from(price)
+        return 0.0 if contains?(price)
+
+        price > top ? price - top : bottom - price
+      end
+
+      # Is price close enough to treat the zone as live? Measured in ATR so a
+      # 4h zone on ETH and a 5m zone on SOL are judged on the same scale.
+      def near?(price, atr, multiple: 0.75)
+        return contains?(price) if atr.to_f <= 0
+
+        distance_from(price) <= (atr * multiple)
+      end
+
+      def label
+        "#{direction == :bullish ? 'Bullish' : 'Bearish'} #{kind.to_s.tr('_', ' ').upcase}"
+      end
+
+      def to_h
+        { kind: kind, direction: direction, top: top, bottom: bottom, time: time,
+          tapped: tapped, invalidated: invalidated }
+      end
+    end
+  end
+end

--- a/config/initializers/crypto_smc_scanner.rb
+++ b/config/initializers/crypto_smc_scanner.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Optional in-process start for the crypto SMC scanner.
+#
+# The supported way to run the scanner is a dedicated process:
+#
+#   bundle exec rake crypto:stream
+#
+# This app is deployed as a single Render web service with no cron service and
+# `:async` for Active Job, so there is nowhere else for a long-running listener
+# to live. CRYPTO_SMC_AUTOSTART=true starts one inside the web process, in the
+# same spirit as the token-refresh thread that already runs there.
+#
+# Two caveats, both deliberate rather than bugs:
+#
+#   * Puma runs WEB_CONCURRENCY workers, and each one boots this file, so a
+#     multi-worker deploy opens a socket per worker. They cannot double-alert —
+#     AlertDispatcher's shared cooldown is keyed on the setup, not the process —
+#     but they do duplicate the Binance traffic. Prefer the dedicated process.
+#   * Nothing starts unless CRYPTO_SMC_ENABLED is also true, so this file is
+#     inert on every existing deployment.
+Rails.application.config.after_initialize do
+  next unless ENV.fetch('CRYPTO_SMC_AUTOSTART', 'false').to_s.downcase == 'true'
+  next unless Crypto::Config.enabled?
+  next if Rails.env.test?
+  # Rake tasks, migrations and consoles have no business holding a socket open.
+  next if defined?(Rails::Console) || File.basename($PROGRAM_NAME) == 'rake'
+
+  Thread.new do
+    Thread.current.name = 'crypto-smc-stream'
+    Thread.current.abort_on_exception = false
+
+    begin
+      Rails.logger.info('[Crypto] autostarting SMC kline stream')
+      Crypto::Binance::KlineStream.new.run
+    rescue StandardError => e
+      Rails.logger.error("[Crypto] kline stream thread died: #{e.class} - #{e.message}")
+    end
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,10 +1,24 @@
-# production:
-#   periodic_cleanup:
-#     class: CleanSoftDeletedRecordsJob
-#     queue: background
-#     args: [ 1000, { batch_size: 500 } ]
-#     schedule: every hour
-#   periodic_command:
-#     command: "SoftDeletedRecord.due.delete_all"
-#     priority: 2
-#     schedule: at 5am every day
+# Solid Queue recurring tasks.
+#
+# Crypto::SmcScanJob is the scheduled half of the SMC/ICT scanner; the
+# event-driven half is `rails crypto:stream`, which fires on candle close.
+# Both are inert unless CRYPTO_SMC_ENABLED=true, so enabling the schedule here
+# does not start alerting on its own.
+#
+# Five minutes matches the execution timeframe: every 5m candle close gets a
+# read even when the stream process is not running.
+
+default: &default
+  crypto_smc_scan:
+    class: Crypto::SmcScanJob
+    queue: default
+    schedule: every 5 minutes
+
+development:
+  <<: *default
+
+production:
+  <<: *default
+
+# Recurring tasks are skipped in test; the job is exercised directly by specs.
+test: {}

--- a/docs/CRYPTO_SMC.md
+++ b/docs/CRYPTO_SMC.md
@@ -1,0 +1,210 @@
+# Crypto SMC/ICT scanner
+
+Analysis-only scanner for **SOLUSDT** and **ETHUSDT** on Binance USD-M futures.
+It reads price, looks for Smart Money Concepts / ICT setups across five
+timeframes, and sends a Telegram message **only when a LONG or SHORT setup
+clears every gate**. It places no orders, holds no API keys, and writes nothing
+to the database.
+
+The DhanHQ side of this app is untouched by all of it — different broker,
+different market, no shared code path.
+
+---
+
+## What it looks for
+
+Top-down, one question per timeframe:
+
+| Timeframe | Question it answers | Feeds |
+|---|---|---|
+| `1d` | Which way is the market drawing? | directional bias |
+| `4h` | Same, with more resolution | directional bias |
+| `1h` | Is structure with us, and are we cheap? | bias + premium/discount |
+| `15m` | Is there a POI, and was liquidity taken? | entry zone, stop anchor |
+| `5m` | Has intent actually shown up? | **the trigger** |
+
+### The primitives
+
+- **Market structure** (`Smc::Structure`) — BOS (continuation) and CHoCH
+  (reversal). A break is confirmed on a **close**, never a wick; a wick through
+  a level that closes back inside is a sweep, which is the opposite signal.
+- **Order blocks** (`Smc::OrderBlocks`) — the last opposing candle before the
+  impulse that broke structure. Detection starts from the break and walks
+  backwards, so a candle only qualifies if displacement actually followed it.
+- **Fair value gaps** (`Smc::FairValueGaps`) — three-candle imbalances, filtered
+  against ATR so dust is ignored. Tracked as tapped vs. fully filled.
+- **Liquidity** (`Smc::Liquidity`) — equal highs/lows as pools, and sweeps of
+  the *most recent* pivot. Taking out highs and rejecting is bearish; taking out
+  lows and rejecting is bullish.
+- **Premium / discount** (`Smc::PremiumDiscount`) — position in the dealing
+  range, plus the 0.618–0.79 OTE band. Longs want discount, shorts want premium.
+- **Price action** (`Smc::PriceAction`) — displacement, engulfing, rejection
+  wicks. Confirmation only, weighted lightly.
+
+Every threshold is ATR-relative, so one set of numbers works on a $4,000 ETH
+candle and a $150 SOL candle.
+
+### How a setup is scored
+
+`SetupDetector` weights thirteen confluences to a total of 122, then normalises
+to 100:
+
+| Confluence | Weight | | Confluence | Weight |
+|---|---|---|---|---|
+| 1d aligned | 15 | | 15m POI active | 15 |
+| 4h aligned | 15 | | 15m liquidity swept | 12 |
+| 1h aligned | 10 | | **5m trigger** | **15** |
+| 1h CHoCH | 6 | | 5m displacement | 5 |
+| Premium/discount correct | 10 | | 5m imbalance | 5 |
+| Price in OTE | 5 | | 5m engulfing/rejection | 4 |
+| | | | Liquidity target beyond entry | 5 |
+
+**Hard gates** — a setup is discarded unless all hold:
+
+1. A 5m BOS or CHoCH in the trade's direction exists (no trigger, no trade).
+2. The 1d and 4h biases do not *both* oppose the direction.
+3. Score ≥ `CRYPTO_SMC_MIN_SCORE` (default 62).
+4. Reward:risk to TP1 ≥ `CRYPTO_SMC_MIN_RR` (default 1.8).
+5. The stop is no wider than `CRYPTO_SMC_MAX_STOP_ATR` × the 15m ATR.
+
+Direction itself is a weighted vote (1d ×2, 4h ×2, 1h ×1) rather than a gate,
+so a genuine 4h reversal is not discarded merely for disagreeing with a daily
+trend it has just begun to end. It still loses the alignment points and has to
+earn the score elsewhere.
+
+### Levels
+
+- **Entry** — the 5m close.
+- **Stop** — beyond the furthest of {POI edge, swept level, recent 5m swing},
+  plus 0.3 × the 5m ATR.
+- **TP1** — the nearest 15m liquidity pool, floored at 1.5R.
+- **TP2** — the 1h pool, floored at TP1 + 0.75R so the targets can never invert.
+
+---
+
+## Running it
+
+Two triggers, one code path (`Crypto::Scanner`), so they cannot disagree about
+what a setup is.
+
+### Event-based (primary)
+
+```bash
+CRYPTO_SMC_ENABLED=true bundle exec rake crypto:stream
+```
+
+Opens one combined Binance WebSocket for every symbol × timeframe and scans the
+moment a candle closes (`k.x`), because an SMC read is only meaningful on closed
+candles. Reconnects with backoff — Binance drops a stream every 24h by design.
+
+This process also carries a **safety-net scan every 5 minutes** for any symbol
+the stream has not already covered. That is deliberate: this app has no
+scheduler (Solid Queue's recurring tasks need `bin/jobs`, the deployed Active
+Job adapter is `:async`, and there is no cron service), so the interval scan
+lives with the listener rather than in a crontab that may not exist.
+
+### Scheduled
+
+`Crypto::SmcScanJob` runs the same sweep and is wired into `config/recurring.yml`
+at five minutes, for deployments that *do* run the Solid Queue supervisor.
+
+### One-off
+
+```bash
+rake crypto:config                 # show resolved settings
+rake crypto:report SYMBOL=ETHUSDT  # full MTF read, no Telegram
+rake crypto:scan                   # scan and alert now
+rake crypto:scan SYMBOLS=SOLUSDT
+```
+
+`crypto:report` prints each timeframe's bias and the reason a chart did *not*
+qualify — the first thing to reach for when the scanner seems too quiet.
+
+### In-process
+
+`CRYPTO_SMC_AUTOSTART=true` starts the listener in a thread inside the web
+process (see `config/initializers/crypto_smc_scanner.rb`). Convenient on a
+single-service deploy; note a multi-worker Puma opens one socket per worker.
+They cannot double-alert — the cooldown is keyed on the setup, not the process —
+but they do duplicate the Binance traffic. Prefer the dedicated process.
+
+---
+
+## Notifications
+
+One message per setup, plain text so no level ever needs escaping:
+
+```
+🟢 LONG  SOLUSDT
+SMC / ICT setup · grade A · score 79.5/100
+
+🎯 Entry   152.345
+🛑 Stop    148.900   (-2.26%)
+✅ TP1     162.500   (6.67%)
+✅ TP2     171.000   (12.24%)
+⚖️ Risk    3.4450 per unit · R:R 2.95
+
+🧭 Bias
+1d ↑  4h ↑  1h ↑  15m ↑  5m ↑
+Range: discount
+
+📋 Confluence
+• 1d structure bullish
+• 15m unmitigated order block 149.900–151.500
+• 15m sell-side liquidity swept at 149.100
+• 5m BOS through 151.900
+
+🕒 28 Jul 2026 14:35 IST
+Analysis only — no order was placed.
+```
+
+**Suppression** is two-layered, because two processes can dispatch: an
+in-process hash, plus a `Rails.cache` entry shared across processes. Both are
+keyed on symbol + side + POI band and expire with
+`CRYPTO_SMC_COOLDOWN_MINUTES` (default 45). Re-running the scan on an unchanged
+chart is silent. The cache entry is a short-lived mutex, not a record — nothing
+about the analysis is stored.
+
+---
+
+## Configuration
+
+All settings live in `Crypto::Config`; see `.env.example` for the full list.
+The important one is the master switch:
+
+```bash
+CRYPTO_SMC_ENABLED=false   # everything else is inert while this is false
+```
+
+Alerts go to `CRYPTO_TELEGRAM_CHAT_ID`, falling back to `TELEGRAM_CHAT_ID`.
+
+### Geo-restriction
+
+Binance returns **HTTP 451** to IPs in restricted regions, and many cloud
+providers' US ranges are among them. If `rake crypto:scan` logs
+`responded 451: Service unavailable from a restricted location`, the code is
+fine and the egress IP is the problem. Point `CRYPTO_BINANCE_BASE` at a
+reachable host, or run the scanner from a region Binance serves. The failure is
+handled cleanly either way — `Analyzer` logs it and returns nil, so a blocked
+region means no alerts rather than a crash.
+
+---
+
+## Design notes
+
+- **No persistence.** Candles are fetched, analysed and dropped. There is no
+  model, no migration, and no setup history — the Telegram message is the whole
+  output.
+- **No credentials.** `Crypto::Binance::Client` has no signed-request path at
+  all, so it cannot place an order even if something asked it to.
+- **`SmcScanJob` is not an `ApplicationJob`.** That base class mints a DhanHQ
+  token before every perform and re-raises on failure, which would take the
+  crypto scanner down whenever the Dhan session lapsed — an unrelated broker, in
+  a market that is closed for most of the hours this job runs.
+- **Retries are off.** By the time a retry landed, the 5m candle that triggered
+  it would have been replaced; an alert on it would describe a chart that no
+  longer exists. The next scan is the retry.
+- **`Crypto::Candle` is not the app's `Candle`.** The latter rounds every price
+  through `PriceMath.round_tick` (an NSE 0.05 tick) and casts volume with
+  `to_i`. Both are wrong for a pair quoting three decimals with fractional
+  volume.

--- a/lib/tasks/crypto.rake
+++ b/lib/tasks/crypto.rake
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+namespace :crypto do
+  desc 'Scan the configured pairs for SMC/ICT setups and alert on Telegram. SYMBOLS=SOLUSDT,ETHUSDT'
+  task scan: :environment do
+    symbols = ENV['SYMBOLS'].to_s.split(',').map { |s| s.strip.upcase }.reject(&:empty?)
+    results = Crypto::Scanner.call(symbols: symbols.presence)
+
+    if results.empty?
+      puts "No qualifying setups (#{(symbols.presence || Crypto::Config.symbols).join(', ')})."
+      next
+    end
+
+    results.each do |result|
+      setup = result.setup
+      puts "#{setup.symbol} #{setup.side} · grade #{setup.grade} · score #{setup.score} · " \
+           "R:R #{setup.risk_reward} · telegram=#{result.status}"
+    end
+  end
+
+  desc 'Print the multi-timeframe SMC read for one pair without alerting. SYMBOL=SOLUSDT'
+  task report: :environment do
+    symbol = (ENV['SYMBOL'].presence || Crypto::Config.symbols.first).upcase
+    analyzer = Crypto::Analyzer.new(symbol)
+    reports = analyzer.reports
+
+    abort("❌ Could not fetch market data for #{symbol}") if reports.nil?
+
+    puts "── #{symbol} ─────────────────────────────"
+    Crypto::Config::TIMEFRAMES.each do |timeframe|
+      report = reports[timeframe]
+      summary = report.summary
+      puts format('%-4<tf>s bias=%-8<bias>s price=%-12<price>s zone=%-12<zone>s last=%<event>s',
+                  tf: timeframe,
+                  bias: summary[:bias],
+                  price: Crypto::Formatting.price(summary[:price]),
+                  zone: summary[:zone] || 'n/a',
+                  event: summary[:last_event] || 'none')
+    end
+
+    setup = Crypto::SetupDetector.call(symbol: symbol, reports: reports)
+    puts
+    if setup
+      puts Crypto::SetupFormatter.call(setup)
+    else
+      puts "No qualifying setup — needs a 5m trigger, score >= #{Crypto::Config.min_score} " \
+           "and R:R >= #{Crypto::Config.min_risk_reward}."
+    end
+  end
+
+  desc 'Run the event-driven kline stream: scans the moment a candle closes'
+  task stream: :environment do
+    abort('❌ CRYPTO_SMC_ENABLED is not true — refusing to start the stream.') unless Crypto::Config.enabled?
+
+    stream = Crypto::Binance::KlineStream.new
+    puts "⚡ streaming #{stream.symbols.join(', ')} on #{stream.timeframes.join(', ')} — Ctrl-C to stop."
+
+    trap('INT') do
+      puts "\n… stopping stream"
+      EM.stop if EM.reactor_running?
+      exit 0
+    end
+
+    stream.run
+  end
+
+  desc 'Show the resolved scanner configuration'
+  task config: :environment do
+    puts "enabled:        #{Crypto::Config.enabled?}"
+    puts "symbols:        #{Crypto::Config.symbols.join(', ')}"
+    puts "timeframes:     #{Crypto::Config::TIMEFRAMES.join(', ')} (execution: #{Crypto::Config::EXECUTION_TIMEFRAME})"
+    puts "stream on:      #{Crypto::Config.stream_timeframes.join(', ')}"
+    puts "min score:      #{Crypto::Config.min_score}"
+    puts "min R:R:        #{Crypto::Config.min_risk_reward}"
+    puts "cooldown:       #{(Crypto::Config.cooldown_seconds / 60).round} min"
+    puts "telegram chat:  #{Crypto::Config.telegram_chat_id.presence || '(unset)'}"
+  end
+end

--- a/spec/jobs/crypto/smc_scan_job_spec.rb
+++ b/spec/jobs/crypto/smc_scan_job_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::SmcScanJob do
+  before { allow(Crypto::Scanner).to receive(:call).and_return([]) }
+
+  context 'when the scanner is disabled' do
+    before { allow(Crypto::Config).to receive(:enabled?).and_return(false) }
+
+    it 'does nothing at all' do
+      described_class.perform_now
+
+      expect(Crypto::Scanner).not_to have_received(:call)
+    end
+  end
+
+  context 'when the scanner is enabled' do
+    before { allow(Crypto::Config).to receive(:enabled?).and_return(true) }
+
+    it 'scans every configured symbol by default' do
+      described_class.perform_now
+
+      expect(Crypto::Scanner).to have_received(:call).with(symbols: nil)
+    end
+
+    it 'scans only the symbols it was given' do
+      described_class.perform_now(%w[SOLUSDT])
+
+      expect(Crypto::Scanner).to have_received(:call).with(symbols: %w[SOLUSDT])
+    end
+
+    it 'accepts a bare symbol' do
+      described_class.perform_now('ETHUSDT')
+
+      expect(Crypto::Scanner).to have_received(:call).with(symbols: %w[ETHUSDT])
+    end
+
+    it 'discards a failed scan instead of retrying it onto a stale candle' do
+      allow(Crypto::Scanner).to receive(:call).and_raise(StandardError, 'binance down')
+
+      expect { described_class.perform_now }.not_to raise_error
+    end
+  end
+
+  it 'does not inherit the DhanHQ token check that guards ApplicationJob' do
+    # Binance market data needs no credential, and a lapsed Dhan session must
+    # not take the crypto scanner down with it.
+    expect(described_class.superclass).to eq(ActiveJob::Base)
+    expect(described_class.ancestors).not_to include(ApplicationJob)
+  end
+end

--- a/spec/services/crypto/alert_dispatcher_spec.rb
+++ b/spec/services/crypto/alert_dispatcher_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::AlertDispatcher do
+  let(:poi) do
+    Crypto::Smc::Zone.new(kind: :order_block, direction: :bullish, top: 99.0, bottom: 97.5,
+                          index: 50, time: Time.current)
+  end
+
+  def build_setup(symbol: 'SOLUSDT', direction: :long, poi_zone: poi)
+    Crypto::Setup.new(
+      symbol: symbol, direction: direction, score: 80.0, entry: 100.0, stop: 97.2,
+      targets: [108.0, 115.0], risk: 2.8, risk_reward: 2.86,
+      confluences: [{ key: :m5_trigger, weight: 15, label: '5m BOS' }], poi: poi_zone
+    )
+  end
+
+  before do
+    described_class.reset!
+    allow(TelegramNotifier).to receive(:send_message)
+    allow(Crypto::Config).to receive(:telegram_chat_id).and_return('-100123')
+  end
+
+  it 'sends the formatted setup to the configured chat' do
+    expect(described_class.dispatch(build_setup)).to eq(:sent)
+    expect(TelegramNotifier).to have_received(:send_message).with(
+      a_string_including('LONG', 'SOLUSDT'), chat_id: '-100123'
+    )
+  end
+
+  it 'stays silent the second time the same setup is seen' do
+    expect(described_class.dispatch(build_setup)).to eq(:sent)
+    expect(described_class.dispatch(build_setup)).to eq(:suppressed)
+
+    expect(TelegramNotifier).to have_received(:send_message).once
+  end
+
+  it 'still alerts when the other side of the same pair sets up' do
+    described_class.dispatch(build_setup(direction: :long))
+
+    expect(described_class.dispatch(build_setup(direction: :short))).to eq(:sent)
+  end
+
+  it 'still alerts for a different pair' do
+    described_class.dispatch(build_setup(symbol: 'SOLUSDT'))
+
+    expect(described_class.dispatch(build_setup(symbol: 'ETHUSDT'))).to eq(:sent)
+  end
+
+  it 'alerts again once the cooldown has passed' do
+    allow(Crypto::Config).to receive(:cooldown_seconds).and_return(60)
+
+    described_class.dispatch(build_setup)
+
+    travel_to(61.seconds.from_now) do
+      Rails.cache.clear # the shared half expires on its own TTL
+      expect(described_class.dispatch(build_setup)).to eq(:sent)
+    end
+  end
+
+  it 'suppresses across processes via the shared cooldown' do
+    described_class.dispatch(build_setup)
+    described_class.reset! # simulate a second process with a cold in-memory store
+
+    expect(described_class.dispatch(build_setup)).to eq(:suppressed)
+  end
+
+  it 'reports when no chat is configured rather than raising' do
+    allow(Crypto::Config).to receive(:telegram_chat_id).and_return(nil)
+
+    expect(described_class.dispatch(build_setup)).to eq(:unconfigured)
+    expect(TelegramNotifier).not_to have_received(:send_message)
+  end
+
+  it 'reports a delivery failure without propagating it' do
+    allow(TelegramNotifier).to receive(:send_message).and_raise(StandardError, 'telegram down')
+
+    expect(described_class.dispatch(build_setup)).to eq(:failed)
+  end
+
+  it 'falls back to the in-process cooldown when the shared cache is unavailable' do
+    allow(Rails.cache).to receive(:read).and_raise(StandardError, 'cache down')
+    allow(Rails.cache).to receive(:write).and_raise(StandardError, 'cache down')
+
+    expect(described_class.dispatch(build_setup)).to eq(:sent)
+    expect(described_class.dispatch(build_setup)).to eq(:suppressed)
+  end
+end

--- a/spec/services/crypto/analyzer_spec.rb
+++ b/spec/services/crypto/analyzer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::Analyzer do
+  let(:base) { 'https://fapi.binance.com' }
+
+  def stub_klines(bars)
+    stub_request(:get, "#{base}/fapi/v1/klines")
+      .with(query: hash_including({}))
+      .to_return(status: 200, body: binance_rows(bars).to_json)
+  end
+
+  it 'normalises the symbol before requesting anything' do
+    stub_klines(zigzag_bars(legs: 12))
+
+    expect(described_class.new('sol/usdt').symbol).to eq('SOLUSDT')
+  end
+
+  it 'builds a report for every configured timeframe' do
+    stub_klines(zigzag_bars(legs: 14))
+
+    reports = described_class.new('SOLUSDT').reports
+
+    expect(reports.keys).to match_array(Crypto::Config::TIMEFRAMES)
+    expect(reports.values).to all(be_a(Crypto::Smc::TimeframeReport))
+  end
+
+  it 'returns nil rather than half a picture when a timeframe fails' do
+    stub_request(:get, "#{base}/fapi/v1/klines")
+      .with(query: hash_including({}))
+      .to_return(status: 451, body: 'restricted')
+
+    expect(described_class.new('SOLUSDT').call).to be_nil
+  end
+
+  it 'returns nil when a timeframe comes back too short to analyse' do
+    stub_klines(zigzag_bars(legs: 1, step: 4))
+
+    expect(described_class.new('SOLUSDT').call).to be_nil
+  end
+
+  it 'hands the reports to the detector and returns its verdict' do
+    stub_klines(zigzag_bars(legs: 14))
+    allow(Crypto::SetupDetector).to receive(:call).and_return(:a_setup)
+
+    expect(described_class.new('SOLUSDT').call).to eq(:a_setup)
+    expect(Crypto::SetupDetector).to have_received(:call)
+      .with(hash_including(symbol: 'SOLUSDT'))
+  end
+
+  it 'never places an order — the client has no signed request path' do
+    expect(Crypto::Binance::Client.instance_methods).not_to include(:place_order, :sign, :signed_request)
+  end
+end

--- a/spec/services/crypto/binance/client_spec.rb
+++ b/spec/services/crypto/binance/client_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::Binance::Client do
+  subject(:client) { described_class.new }
+
+  let(:base) { 'https://fapi.binance.com' }
+
+  describe '#normalize_symbol' do
+    it 'accepts the shapes a human or another exchange would write' do
+      expect(client.normalize_symbol('solusdt')).to eq('SOLUSDT')
+      expect(client.normalize_symbol('SOL/USDT')).to eq('SOLUSDT')
+      expect(client.normalize_symbol('SOL-USDT')).to eq('SOLUSDT')
+      expect(client.normalize_symbol('eth_usdt')).to eq('ETHUSDT')
+    end
+  end
+
+  describe '#klines' do
+    it 'requests the public endpoint with no credentials attached' do
+      stub = stub_request(:get, "#{base}/fapi/v1/klines")
+        .with(query: { symbol: 'SOLUSDT', interval: '15m', limit: '200' })
+        .to_return(status: 200, body: binance_rows([[100, 101, 99, 100]]).to_json)
+
+      client.klines(symbol: 'sol/usdt', interval: '15m', limit: 200)
+
+      expect(stub).to have_been_requested
+      expect(a_request(:get, %r{fapi/v1/klines}).with(headers: { 'X-MBX-APIKEY' => /.*/ })).not_to have_been_made
+    end
+
+    it 'caps the limit at what Binance accepts' do
+      stub = stub_request(:get, "#{base}/fapi/v1/klines")
+        .with(query: hash_including(limit: '1500'))
+        .to_return(status: 200, body: '[]')
+
+      client.klines(symbol: 'SOLUSDT', interval: '5m', limit: 99_999)
+
+      expect(stub).to have_been_requested
+    end
+
+    it 'raises a typed error on an API rejection' do
+      stub_request(:get, "#{base}/fapi/v1/klines")
+        .with(query: hash_including({}))
+        .to_return(status: 400, body: '{"code":-1121,"msg":"Invalid symbol."}')
+
+      expect { client.klines(symbol: 'NOPEUSDT', interval: '5m') }
+        .to raise_error(Crypto::Binance::Error, /responded 400/)
+    end
+
+    it 'does not retry an API rejection, which would fail identically' do
+      stub = stub_request(:get, "#{base}/fapi/v1/klines")
+        .with(query: hash_including({}))
+        .to_return(status: 451, body: 'restricted')
+
+      expect { client.klines(symbol: 'SOLUSDT', interval: '5m') }.to raise_error(Crypto::Binance::Error)
+      expect(stub).to have_been_requested.once
+    end
+
+    it 'retries a transport fault and succeeds on a later attempt' do
+      stub_request(:get, "#{base}/fapi/v1/klines")
+        .with(query: hash_including({}))
+        .to_timeout.then
+        .to_return(status: 200, body: binance_rows([[100, 101, 99, 100]]).to_json)
+
+      expect(client.klines(symbol: 'SOLUSDT', interval: '5m').size).to eq(1)
+    end
+  end
+
+  describe '#series' do
+    it 'returns a Series built from the raw rows' do
+      stub_request(:get, "#{base}/fapi/v1/klines")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: binance_rows([[100, 101, 99, 100], [100, 104, 100, 103]]).to_json)
+
+      series = client.series(symbol: 'SOLUSDT', interval: '5m', limit: 2)
+
+      expect(series).to be_a(Crypto::Series)
+      expect(series.size).to eq(2)
+      expect(series.last_price).to eq(103.0)
+      expect(series.timeframe).to eq('5m')
+    end
+  end
+
+  describe '#last_price' do
+    it 'reads the ticker endpoint' do
+      stub_request(:get, "#{base}/fapi/v1/ticker/price")
+        .with(query: { symbol: 'ETHUSDT' })
+        .to_return(status: 200, body: '{"symbol":"ETHUSDT","price":"3421.55"}')
+
+      expect(client.last_price('ETHUSDT')).to eq(3421.55)
+    end
+  end
+
+  describe 'base url override' do
+    it 'honours CRYPTO_BINANCE_BASE so a restricted region can point elsewhere' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('CRYPTO_BINANCE_BASE').and_return('https://testnet.binancefuture.com')
+
+      stub = stub_request(:get, 'https://testnet.binancefuture.com/fapi/v1/klines')
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: '[]')
+
+      described_class.new.klines(symbol: 'SOLUSDT', interval: '5m')
+
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/services/crypto/binance/kline_stream_spec.rb
+++ b/spec/services/crypto/binance/kline_stream_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::Binance::KlineStream do
+  subject(:stream) { described_class.new(symbols: %w[SOLUSDT ETHUSDT], timeframes: %w[5m 15m], on_close: handler) }
+
+  let(:fired) { [] }
+  let(:handler) { ->(symbol, timeframe) { fired << [symbol, timeframe] } }
+
+  # Shaped like a real combined-stream frame: Binance carries the symbol at
+  # the event level *and* inside the kline.
+  def frame(symbol: 'SOLUSDT', interval: '5m', closed: true)
+    { stream: "#{symbol.downcase}@kline_#{interval}",
+      data: { e: 'kline', E: 1_767_000_000_000, s: symbol,
+              k: { t: 1_767_000_000_000, s: symbol, i: interval, x: closed,
+                   o: '151.00', h: '153.00', l: '150.50', c: '152.30', v: '1200' } } }.to_json
+  end
+
+  # A raw single stream is not wrapped in "data".
+  def raw_frame(symbol: 'SOLUSDT', interval: '5m')
+    { e: 'kline', s: symbol, k: { s: symbol, i: interval, x: true, c: '152.30' } }.to_json
+  end
+
+  describe '#stream_url' do
+    it 'subscribes to every symbol on every timeframe over one socket' do
+      expect(stream.stream_url).to eq(
+        'wss://fstream.binance.com/stream?streams=' \
+        'solusdt@kline_5m/solusdt@kline_15m/ethusdt@kline_5m/ethusdt@kline_15m'
+      )
+    end
+
+    it 'defaults to the configured symbols and stream timeframes' do
+      allow(Crypto::Config).to receive_messages(symbols: %w[SOLUSDT], stream_timeframes: %w[5m])
+
+      expect(described_class.new.stream_url).to end_with('streams=solusdt@kline_5m')
+    end
+  end
+
+  describe 'handling frames' do
+    it 'scans when a candle closes' do
+      stream.send(:handle_message, frame)
+
+      expect(fired).to eq([%w[SOLUSDT 5m]])
+    end
+
+    it 'reads a raw single-stream frame too' do
+      stream.send(:handle_message, raw_frame)
+
+      expect(fired).to eq([%w[SOLUSDT 5m]])
+    end
+
+    it 'ignores a candle that is still forming' do
+      stream.send(:handle_message, frame(closed: false))
+
+      expect(fired).to be_empty
+    end
+
+    it 'collapses two timeframes closing on the same boundary into one scan' do
+      stream.send(:handle_message, frame(interval: '5m'))
+      stream.send(:handle_message, frame(interval: '15m'))
+
+      expect(fired.size).to eq(1)
+    end
+
+    it 'still scans the other symbol on that boundary' do
+      stream.send(:handle_message, frame(symbol: 'SOLUSDT'))
+      stream.send(:handle_message, frame(symbol: 'ETHUSDT'))
+
+      expect(fired.map(&:first)).to eq(%w[SOLUSDT ETHUSDT])
+    end
+
+    it 'scans again once the debounce window has passed' do
+      stream.send(:handle_message, frame)
+
+      travel_to((described_class::DEBOUNCE_SECONDS + 1).seconds.from_now) do
+        stream.send(:handle_message, frame)
+      end
+
+      expect(fired.size).to eq(2)
+    end
+
+    it 'survives an unparseable frame' do
+      expect { stream.send(:handle_message, 'not json') }.not_to raise_error
+      expect(fired).to be_empty
+    end
+
+    it 'ignores a frame that carries no kline' do
+      expect { stream.send(:handle_message, '{"result":null,"id":1}') }.not_to raise_error
+      expect(fired).to be_empty
+    end
+
+    it 'does not let a failing handler kill the socket' do
+      boom = described_class.new(symbols: %w[SOLUSDT], on_close: ->(_s, _t) { raise 'handler exploded' })
+
+      expect { boom.send(:handle_message, frame) }.not_to raise_error
+    end
+  end
+
+  describe 'the safety-net scan' do
+    it 'skips a symbol the stream already covered' do
+      stream.send(:handle_message, frame(symbol: 'SOLUSDT'))
+
+      expect(stream.send(:recently_scanned?, 'SOLUSDT')).to be(true)
+      expect(stream.send(:recently_scanned?, 'ETHUSDT')).to be(false)
+    end
+
+    it 'covers a symbol again once the interval lapses' do
+      stream.send(:handle_message, frame(symbol: 'SOLUSDT'))
+
+      travel_to((described_class::SAFETY_SCAN_INTERVAL + 1).seconds.from_now) do
+        expect(stream.send(:recently_scanned?, 'SOLUSDT')).to be(false)
+      end
+    end
+  end
+end

--- a/spec/services/crypto/scanner_spec.rb
+++ b/spec/services/crypto/scanner_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::Scanner do
+  let(:setup) do
+    Crypto::Setup.new(symbol: 'SOLUSDT', direction: :long, score: 80.0, entry: 100.0, stop: 97.0,
+                      targets: [106.0, 112.0], risk: 3.0, risk_reward: 2.0, confluences: [])
+  end
+
+  let(:analyzer) { instance_double(Crypto::Analyzer) }
+
+  before do
+    allow(Crypto::Analyzer).to receive(:new).and_return(analyzer)
+    allow(Crypto::AlertDispatcher).to receive(:dispatch).and_return(:sent)
+  end
+
+  it 'returns nothing when no symbol produces a setup' do
+    allow(analyzer).to receive(:call).and_return(nil)
+
+    expect(described_class.call(symbols: %w[SOLUSDT ETHUSDT])).to be_empty
+    expect(Crypto::AlertDispatcher).not_to have_received(:dispatch)
+  end
+
+  it 'dispatches each setup it finds' do
+    allow(analyzer).to receive(:call).and_return(setup)
+
+    results = described_class.call(symbols: %w[SOLUSDT])
+
+    expect(results.size).to eq(1)
+    expect(results.first).to be_alerted
+    expect(Crypto::AlertDispatcher).to have_received(:dispatch).with(setup)
+  end
+
+  it 'can analyse without notifying' do
+    allow(analyzer).to receive(:call).and_return(setup)
+
+    results = described_class.call(symbols: %w[SOLUSDT], notify: false)
+
+    expect(results.first.status).to eq(:skipped)
+    expect(Crypto::AlertDispatcher).not_to have_received(:dispatch)
+  end
+
+  it 'defaults to the configured symbols' do
+    allow(Crypto::Config).to receive(:symbols).and_return(%w[SOLUSDT ETHUSDT])
+    allow(analyzer).to receive(:call).and_return(nil)
+
+    described_class.call
+
+    expect(Crypto::Analyzer).to have_received(:new).twice
+  end
+
+  it 'carries on with the next symbol when one blows up' do
+    allow(analyzer).to receive(:call).and_raise(StandardError, 'boom')
+
+    expect { described_class.call(symbols: %w[SOLUSDT ETHUSDT]) }.not_to raise_error
+  end
+end

--- a/spec/services/crypto/series_spec.rb
+++ b/spec/services/crypto/series_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::Series do
+  describe '#swing_highs' do
+    it 'finds the pivot and reports when it became knowable' do
+      # bar 2 is the peak; with strength 2 it is only confirmed at bar 4
+      series = crypto_series([
+                               [100, 101, 99, 100],
+                               [100, 103, 100, 102],
+                               [102, 110, 101, 108],
+                               [108, 106, 104, 105],
+                               [105, 104, 102, 103]
+                             ])
+
+      pivots = series.swing_highs(strength: 2)
+
+      expect(pivots.size).to eq(1)
+      expect(pivots.first).to include(index: 2, price: 110.0, confirmed_at: 4)
+    end
+
+    it 'ignores a peak that has too few bars to its right to confirm' do
+      series = crypto_series([
+                               [100, 101, 99, 100],
+                               [100, 103, 100, 102],
+                               [102, 110, 101, 108],
+                               [108, 106, 104, 105]
+                             ])
+
+      expect(series.swing_highs(strength: 2)).to be_empty
+    end
+  end
+
+  describe '#swing_lows' do
+    it 'finds the trough' do
+      series = crypto_series([
+                               [100, 101, 99, 100],
+                               [100, 100, 96, 97],
+                               [97, 98, 90, 92],
+                               [92, 96, 93, 95],
+                               [95, 99, 94, 98]
+                             ])
+
+      pivots = series.swing_lows(strength: 2)
+
+      expect(pivots.pluck(:price)).to eq([90.0])
+    end
+  end
+
+  describe '#atr' do
+    it 'is zero when there is not enough history to measure a range' do
+      expect(crypto_series([[100, 101, 99, 100]]).atr).to eq(0.0)
+    end
+
+    it 'averages the true range of the last n bars' do
+      series = crypto_series([
+                               [100, 102, 98, 100],
+                               [100, 104, 100, 103],
+                               [103, 105, 101, 102]
+                             ])
+
+      # TRs: max(4, 4, 0)=4 then max(4, 2, 2)=4
+      expect(series.atr(2)).to eq(4.0)
+    end
+  end
+
+  describe '#from_binance' do
+    it 'builds candles from raw kline rows without tick-rounding the price' do
+      rows = binance_rows([[145.123, 146.987, 144.001, 146.456]])
+      series = described_class.from_binance(symbol: 'SOLUSDT', timeframe: '5m', rows: rows)
+
+      expect(series.size).to eq(1)
+      expect(series.last.close).to eq(146.456)
+      expect(series.last.volume).to eq(1000.5)
+    end
+  end
+end

--- a/spec/services/crypto/setup_detector_spec.rb
+++ b/spec/services/crypto/setup_detector_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::SetupDetector do
+  # The detector's job is to decide, so these specs feed it a controlled view
+  # of each timeframe and assert on the decision. The detectors that build
+  # those views have their own specs.
+  def build_report(bias:, price: 100.0, atr: 1.0, poi: nil, sweep: nil, trigger: nil,
+                   favourable: true, ote: true, displacement: true, confirmation: true,
+                   imbalance: true, target_above: nil, target_below: nil, size: 60)
+    bars = Array.new(size) { [price, price + 1, price - 2, price] }
+    series = crypto_series(bars)
+
+    instance_double(
+      Crypto::Smc::TimeframeReport,
+      bias: bias, price: price, atr: atr, series: series,
+      structure: instance_double(
+        Crypto::Smc::Structure,
+        recent_event: trigger,
+        next_liquidity_above: target_above,
+        next_liquidity_below: target_below
+      ),
+      premium_discount: instance_double(
+        Crypto::Smc::PremiumDiscount,
+        favourable?: favourable, in_ote?: ote, zone: :discount
+      ),
+      active_poi: poi,
+      liquidity: instance_double(
+        Crypto::Smc::Liquidity,
+        recent_sweep: sweep, target_above: target_above, target_below: target_below
+      ),
+      price_action: instance_double(
+        Crypto::Smc::PriceAction,
+        displacement?: displacement, engulfing?: confirmation, rejection?: confirmation
+      ),
+      fair_value_gaps: instance_double(
+        Crypto::Smc::FairValueGaps,
+        candidates: imbalance ? [bullish_poi] : []
+      )
+    )
+  end
+
+  let(:bullish_poi) do
+    Crypto::Smc::Zone.new(kind: :order_block, direction: :bullish, top: 99.0, bottom: 97.5,
+                          index: 55, time: Time.current)
+  end
+
+  let(:bullish_sweep) do
+    Crypto::Smc::Liquidity::Sweep.new(direction: :bullish, level: 97.8, index: 55,
+                                      time: Time.current, penetration: 0.4)
+  end
+
+  let(:bullish_trigger) do
+    Crypto::Smc::Structure::Event.new(type: :bos, direction: :bullish, level: 99.5,
+                                      index: 55, time: Time.current)
+  end
+
+  # A complete, textbook long: every timeframe aligned, POI tapped, liquidity
+  # swept, 5m broken structure upward, targets in place.
+  def long_reports(overrides = {})
+    defaults = {
+      '1d' => build_report(bias: :bullish),
+      '4h' => build_report(bias: :bullish),
+      '1h' => build_report(bias: :bullish, trigger: bullish_trigger, target_above: 115.0),
+      '15m' => build_report(bias: :bullish, atr: 2.0, poi: bullish_poi, sweep: bullish_sweep,
+                            target_above: 108.0),
+      '5m' => build_report(bias: :bullish, trigger: bullish_trigger, target_above: 108.0)
+    }
+    defaults.merge(overrides)
+  end
+
+  describe 'the happy path' do
+    subject(:setup) { described_class.call(symbol: 'SOLUSDT', reports: long_reports) }
+
+    it 'produces a long setup' do
+      expect(setup).to be_a(Crypto::Setup)
+      expect(setup).to be_long
+      expect(setup.symbol).to eq('SOLUSDT')
+    end
+
+    it 'places the stop below the deepest structure plus a buffer' do
+      # anchors: POI bottom 97.5, sweep 97.8, 5m swing low 98 -> 97.5 - (1.0 * 0.3)
+      expect(setup.stop).to be_within(0.001).of(97.2)
+      expect(setup.risk).to be_within(0.001).of(2.8)
+    end
+
+    it 'targets resting liquidity, ordered outward' do
+      expect(setup.target1).to eq(108.0)
+      expect(setup.target2).to eq(115.0)
+      expect(setup.target2).to be > setup.target1
+    end
+
+    it 'reports the reward:risk to the first target' do
+      expect(setup.risk_reward).to eq(2.86)
+    end
+
+    it 'scores every confluence it found' do
+      expect(setup.score).to eq(100.0)
+      expect(setup.grade).to eq('A+')
+      expect(setup.confluences.pluck(:key)).to include(:m5_trigger, :m15_poi, :m15_sweep)
+    end
+  end
+
+  describe 'hard gates' do
+    it 'refuses without a 5m trigger, however good the context' do
+      reports = long_reports('5m' => build_report(bias: :bullish, trigger: nil, target_above: 108.0))
+
+      expect(described_class.call(symbol: 'SOLUSDT', reports: reports)).to be_nil
+    end
+
+    it 'refuses when both higher timeframes oppose the trade' do
+      reports = long_reports(
+        '1d' => build_report(bias: :bearish),
+        '4h' => build_report(bias: :bearish)
+      )
+
+      expect(described_class.call(symbol: 'SOLUSDT', reports: reports)).to be_nil
+    end
+
+    it 'refuses when the timeframes cannot agree on a direction' do
+      reports = long_reports(
+        '1d' => build_report(bias: :bullish),
+        '4h' => build_report(bias: :bearish),
+        '1h' => build_report(bias: :neutral, target_above: 115.0)
+      )
+
+      expect(described_class.call(symbol: 'SOLUSDT', reports: reports)).to be_nil
+    end
+
+    it 'refuses when the score falls below the threshold' do
+      thin = long_reports(
+        '15m' => build_report(bias: :bullish, atr: 2.0, poi: nil, sweep: nil, favourable: false,
+                              ote: false, imbalance: false, target_above: 108.0),
+        '1h' => build_report(bias: :neutral, favourable: false, ote: false, target_above: 115.0)
+      )
+
+      expect(described_class.call(symbol: 'SOLUSDT', reports: thin)).to be_nil
+    end
+
+    it 'refuses when the reward:risk does not clear the minimum' do
+      # Target only just beyond entry, so R:R lands under 1.8.
+      reports = long_reports(
+        '15m' => build_report(bias: :bullish, atr: 2.0, poi: bullish_poi, sweep: bullish_sweep,
+                              target_above: 101.0),
+        '1h' => build_report(bias: :bullish, target_above: 101.5)
+      )
+
+      expect(described_class.call(symbol: 'SOLUSDT', reports: reports, min_risk_reward: 5.0)).to be_nil
+    end
+
+    it 'refuses when the stop is wider than the 15m ATR allows' do
+      # A 15m ATR of 0.5 makes the ceiling 1.25, well under the 2.8 stop.
+      reports = long_reports(
+        '15m' => build_report(bias: :bullish, atr: 0.5, poi: bullish_poi, sweep: bullish_sweep,
+                              target_above: 108.0)
+      )
+
+      expect(described_class.call(symbol: 'SOLUSDT', reports: reports)).to be_nil
+    end
+
+    it 'refuses when a timeframe is missing' do
+      expect(described_class.call(symbol: 'SOLUSDT', reports: long_reports.except('4h'))).to be_nil
+    end
+
+    it 'refuses when a timeframe has too little history to read' do
+      reports = long_reports('1d' => build_report(bias: :bullish, size: 10))
+
+      expect(described_class.call(symbol: 'SOLUSDT', reports: reports)).to be_nil
+    end
+  end
+
+  describe 'shorts' do
+    let(:bearish_poi) do
+      Crypto::Smc::Zone.new(kind: :order_block, direction: :bearish, top: 102.5, bottom: 101.0,
+                            index: 55, time: Time.current)
+    end
+
+    let(:bearish_trigger) do
+      Crypto::Smc::Structure::Event.new(type: :choch, direction: :bearish, level: 100.5,
+                                        index: 55, time: Time.current)
+    end
+
+    it 'mirrors the long logic' do
+      reports = {
+        '1d' => build_report(bias: :bearish),
+        '4h' => build_report(bias: :bearish),
+        '1h' => build_report(bias: :bearish, target_below: 85.0),
+        '15m' => build_report(bias: :bearish, atr: 2.0, poi: bearish_poi, target_below: 92.0),
+        '5m' => build_report(bias: :bearish, trigger: bearish_trigger, target_below: 92.0)
+      }
+
+      setup = described_class.call(symbol: 'ETHUSDT', reports: reports)
+
+      expect(setup).to be_short
+      expect(setup.stop).to be > setup.entry
+      expect(setup.target1).to be < setup.entry
+      expect(setup.target2).to be < setup.target1
+    end
+  end
+end

--- a/spec/services/crypto/setup_formatter_spec.rb
+++ b/spec/services/crypto/setup_formatter_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::SetupFormatter do
+  subject(:message) { described_class.call(setup) }
+
+  let(:setup) do
+    Crypto::Setup.new(
+      symbol: 'SOLUSDT', direction: :long, score: 78.5, entry: 152.345, stop: 148.9,
+      targets: [162.5, 171.0], risk: 3.445, risk_reward: 2.95,
+      confluences: [
+        { key: :daily_alignment, weight: 15, label: '1d structure bullish' },
+        { key: :m5_trigger, weight: 15, label: '5m BOS through 151.900' }
+      ],
+      context: { bias: { '1d' => :bullish, '4h' => :bullish, '1h' => :bullish,
+                         '15m' => :bullish, '5m' => :bullish },
+                 range_zone: :discount }
+    )
+  end
+
+  it 'leads with the side, the pair and the grade' do
+    expect(message).to include('🟢 LONG', 'SOLUSDT', 'grade A', 'score 78.5/100')
+  end
+
+  it 'states every level the trade needs' do
+    expect(message).to include('Entry   152.345', 'Stop    148.900', 'TP1     162.500', 'TP2     171.000')
+    expect(message).to include('R:R 2.95')
+  end
+
+  it 'shows the move to each level as a percentage' do
+    expect(message).to match(/Stop.*-2\.26%/)
+    expect(message).to match(/TP1.*6\.67%/)
+  end
+
+  it 'renders the multi-timeframe bias' do
+    expect(message).to include('1d ↑', '4h ↑', '5m ↑', 'Range: discount')
+  end
+
+  it 'lists the confluences that justified the alert' do
+    expect(message).to include('1d structure bullish', '5m BOS through 151.900')
+  end
+
+  it 'says plainly that nothing was traded' do
+    expect(message).to include('Analysis only — no order was placed.')
+  end
+
+  it 'fits inside a single Telegram message' do
+    expect(message.length).to be < TelegramNotifier::MAX_LEN
+  end
+
+  context 'with a short' do
+    let(:setup) do
+      Crypto::Setup.new(
+        symbol: 'ETHUSDT', direction: :short, score: 66.0, entry: 3400.0, stop: 3450.0,
+        targets: [3300.0, 3250.0], risk: 50.0, risk_reward: 2.0, confluences: []
+      )
+    end
+
+    it 'flips the marker' do
+      expect(message).to include('🔴 SHORT', 'ETHUSDT')
+    end
+  end
+end

--- a/spec/services/crypto/smc/fair_value_gaps_spec.rb
+++ b/spec/services/crypto/smc/fair_value_gaps_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::Smc::FairValueGaps do
+  it 'records a bullish gap where the third bar leaves the first behind' do
+    # bar 0 high 101, bar 2 low 105 -> imbalance 101..105
+    series = crypto_series([
+                             [100, 101, 99, 100],
+                             [100, 106, 100, 105],
+                             [105, 110, 105, 109],
+                             [109, 111, 108, 110],
+                             [110, 112, 109, 111]
+                           ])
+
+    gap = described_class.new(series).bullish.first
+
+    expect(gap).to have_attributes(direction: :bullish, bottom: 101.0, top: 105.0)
+    expect(gap.invalidated?).to be(false)
+  end
+
+  it 'records a bearish gap' do
+    series = crypto_series([
+                             [110, 111, 109, 110],
+                             [110, 110, 104, 105],
+                             [105, 104, 100, 101],
+                             [101, 102, 99, 100],
+                             [100, 101, 98, 99]
+                           ])
+
+    gap = described_class.new(series).bearish.first
+
+    expect(gap).to have_attributes(direction: :bearish, bottom: 104.0, top: 109.0)
+  end
+
+  it 'marks a gap invalidated once price trades all the way back through it' do
+    series = crypto_series([
+                             [100, 101, 99, 100],
+                             [100, 106, 100, 105],
+                             [105, 110, 105, 109],  # gap 101..105
+                             [109, 110, 104, 105],  # tapped
+                             [105, 106, 100, 101],  # traded through the bottom
+                             [101, 103, 100, 102]
+                           ])
+
+    gap = described_class.new(series).bullish.first
+
+    expect(gap.tapped?).to be(true)
+    expect(gap.invalidated?).to be(true)
+  end
+
+  it 'ignores a gap too small to matter against ATR' do
+    # Wide bars set a large ATR; the 0.01 gap between them is noise.
+    series = crypto_series([
+                             [100, 110, 90, 105],
+                             [105, 120, 100, 115],
+                             [115, 125, 110.01, 120],
+                             [120, 126, 112, 121],
+                             [121, 127, 113, 122]
+                           ])
+
+    expect(described_class.new(series).zones).to be_empty
+  end
+
+  describe '#candidates' do
+    let(:series) do
+      crypto_series([
+                      [100, 101, 99, 100],
+                      [100, 106, 100, 105],
+                      [105, 110, 105, 109], # gap 101..105
+                      [109, 115, 109, 114],
+                      [114, 120, 114, 119],
+                      [119, 121, 118, 120]
+                    ])
+    end
+
+    it 'orders by distance from price, nearest first' do
+      candidates = described_class.new(series).candidates(:bullish, 120.0)
+
+      distances = candidates.map { |zone| zone.distance_from(120.0) }
+      expect(distances).to eq(distances.sort)
+      expect(candidates.first.top).to eq(118.0)
+    end
+
+    it 'excludes gaps price has already traded back through' do
+      filled = described_class.new(series).zones.select(&:invalidated?)
+      candidates = described_class.new(series).candidates(:bullish, 120.0)
+
+      expect(candidates).not_to include(*filled) unless filled.empty?
+      expect(candidates).to all(satisfy { |zone| !zone.invalidated? })
+    end
+  end
+end

--- a/spec/services/crypto/smc/liquidity_spec.rb
+++ b/spec/services/crypto/smc/liquidity_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::Smc::Liquidity do
+  def liquidity_for(series)
+    described_class.new(series, Crypto::Smc::Structure.new(series, strength: 2))
+  end
+
+  describe 'sweeps' do
+    it 'reads a wick through the swing high that closes back below as bearish' do
+      series = crypto_series([
+                               [100, 101, 99, 100],
+                               [100, 103, 100, 102],
+                               [102, 110, 101, 108],  # pivot high 110
+                               [108, 108, 104, 105],
+                               [105, 106, 100, 101],
+                               [101, 104, 100, 103],
+                               [103, 113, 102, 106],  # wick to 113, closes under 110
+                               [106, 107, 103, 104],
+                               [104, 105, 101, 102]
+                             ])
+
+      sweep = liquidity_for(series).recent_sweep(:bearish, lookback: 9)
+
+      expect(sweep).to have_attributes(direction: :bearish, level: 110.0)
+      expect(sweep.penetration).to be_within(0.001).of(3.0)
+    end
+
+    it 'reads a wick under the swing low that closes back above as bullish' do
+      series = crypto_series([
+                               [110, 111, 109, 110],
+                               [110, 110, 106, 107],
+                               [107, 108, 100, 102],  # pivot low 100
+                               [102, 106, 101, 105],
+                               [105, 109, 104, 108],
+                               [108, 109, 105, 106],
+                               [106, 107, 97, 105],   # wick to 97, closes above 100
+                               [105, 108, 104, 107],
+                               [107, 110, 106, 109]
+                             ])
+
+      sweep = liquidity_for(series).recent_sweep(:bullish, lookback: 9)
+
+      expect(sweep).to have_attributes(direction: :bullish, level: 100.0)
+    end
+
+    it 'does not call a decisive break a sweep' do
+      series = crypto_series([
+                               [100, 101, 99, 100],
+                               [100, 103, 100, 102],
+                               [102, 110, 101, 108],  # pivot high 110
+                               [108, 108, 104, 105],
+                               [105, 106, 100, 101],
+                               [101, 104, 100, 103],
+                               [103, 114, 102, 113],  # closes ABOVE 110 -> a break
+                               [113, 115, 112, 114],
+                               [114, 116, 113, 115]
+                             ])
+
+      expect(liquidity_for(series).recent_sweep(:bearish, lookback: 9)).to be_nil
+    end
+
+    it 'stays quiet on a chart that never raids a level' do
+      series = crypto_series(zigzag_bars(legs: 6, amplitude: 4.0))
+
+      expect(liquidity_for(series).sweeps.size).to be < series.size / 4
+    end
+  end
+
+  describe 'pools' do
+    it 'clusters near-identical highs into one pool' do
+      series = crypto_series([
+                               [100, 101, 99, 100],
+                               [100, 103, 100, 102],
+                               [102, 110.0, 101, 108],
+                               [108, 108, 104, 105],
+                               [105, 106, 103, 104],
+                               [104, 110.02, 103, 106], # equal high
+                               [106, 107, 103, 104],
+                               [104, 105, 101, 102],
+                               [102, 103, 99, 100]
+                             ])
+
+      pool = liquidity_for(series).equal_highs.max_by(&:strength)
+
+      expect(pool.strength).to be >= 2
+      expect(pool.price).to be_within(0.05).of(110.0)
+    end
+  end
+
+  describe 'targets' do
+    it 'points at the nearest pool beyond price' do
+      series = crypto_series(zigzag_bars(legs: 6, amplitude: 4.0))
+      liquidity = liquidity_for(series)
+      price = series.last_price
+
+      expect(liquidity.target_above(price)).to be > price if liquidity.target_above(price)
+      expect(liquidity.target_below(price)).to be < price if liquidity.target_below(price)
+    end
+  end
+end

--- a/spec/services/crypto/smc/order_blocks_spec.rb
+++ b/spec/services/crypto/smc/order_blocks_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::Smc::OrderBlocks do
+  # Pivot high at 110, pullback, then an impulse that closes through it. The
+  # last down candle before that impulse is the bullish order block.
+  let(:series) do
+    crypto_series([
+                    [100, 101, 99, 100],
+                    [100, 103, 100, 102],
+                    [102, 110, 101, 108],  # pivot high 110
+                    [108, 108, 104, 105],
+                    [105, 106, 100, 101],
+                    [101, 102, 98, 99],    # pivot low 98
+                    [99, 100, 96, 97],     # last bearish candle before the impulse
+                    [97, 104, 97, 103],
+                    [103, 113, 102, 112],  # BOS through 110
+                    [112, 114, 110, 113],
+                    [113, 115, 111, 114]
+                  ])
+  end
+
+  let(:structure) { Crypto::Smc::Structure.new(series, strength: 2) }
+
+  it 'marks the last opposing candle before the break as the order block' do
+    zone = described_class.new(series, structure).bullish.first
+
+    expect(zone).to have_attributes(direction: :bullish, kind: :order_block, bottom: 96.0, top: 100.0)
+  end
+
+  it 'leaves an untouched block fresh' do
+    zone = described_class.new(series, structure).bullish.first
+
+    expect(zone.fresh?).to be(true)
+    expect(zone.tapped?).to be(false)
+  end
+
+  it 'marks the block tapped when price returns into it' do
+    revisit = crypto_series(series.candles.map { |c| [c.open, c.high, c.low, c.close] } +
+                            [[114, 115, 108, 109], [109, 110, 99, 100]])
+    zone = described_class.new(revisit, Crypto::Smc::Structure.new(revisit, strength: 2)).bullish.first
+
+    expect(zone.tapped?).to be(true)
+    expect(zone.invalidated?).to be(false)
+  end
+
+  it 'invalidates the block when price closes below it' do
+    broken = crypto_series(series.candles.map { |c| [c.open, c.high, c.low, c.close] } +
+                           [[114, 115, 100, 101], [101, 102, 92, 93]])
+    zone = described_class.new(broken, Crypto::Smc::Structure.new(broken, strength: 2)).bullish.first
+
+    expect(zone.invalidated?).to be(true)
+    expect(zone.valid?).to be(false)
+  end
+
+  it 'has no blocks when structure never broke' do
+    flat = crypto_series(Array.new(20) { [100, 101, 99, 100] })
+
+    expect(described_class.new(flat, Crypto::Smc::Structure.new(flat, strength: 2)).zones).to be_empty
+  end
+end

--- a/spec/services/crypto/smc/premium_discount_spec.rb
+++ b/spec/services/crypto/smc/premium_discount_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::Smc::PremiumDiscount do
+  subject(:pd) { described_class.new(high: 200.0, low: 100.0) }
+
+  it 'puts equilibrium at the midpoint' do
+    expect(pd.equilibrium).to eq(150.0)
+  end
+
+  describe '#zone' do
+    it 'calls the lower half discount and the upper half premium' do
+      expect(pd.zone(120.0)).to eq(:discount)
+      expect(pd.zone(180.0)).to eq(:premium)
+    end
+
+    it 'treats a band around the midpoint as equilibrium rather than flipping on a tick' do
+      expect(pd.zone(150.0)).to eq(:equilibrium)
+      expect(pd.zone(152.0)).to eq(:equilibrium)
+    end
+  end
+
+  describe '#favourable?' do
+    it 'wants longs in discount and shorts in premium' do
+      expect(pd.favourable?(120.0, :bullish)).to be(true)
+      expect(pd.favourable?(180.0, :bullish)).to be(false)
+      expect(pd.favourable?(180.0, :bearish)).to be(true)
+      expect(pd.favourable?(120.0, :bearish)).to be(false)
+    end
+
+    it 'allows equilibrium either way' do
+      expect(pd.favourable?(150.0, :bullish)).to be(true)
+      expect(pd.favourable?(150.0, :bearish)).to be(true)
+    end
+  end
+
+  describe '#ote' do
+    it 'sits in the lower half of the range for a long' do
+      band = pd.ote(:bullish)
+
+      expect(band[:bottom]).to be_within(0.01).of(121.0) # 200 - 79
+      expect(band[:top]).to be_within(0.01).of(138.2)    # 200 - 61.8
+      expect(pd.in_ote?(130.0, :bullish)).to be(true)
+      expect(pd.in_ote?(190.0, :bullish)).to be(false)
+    end
+
+    it 'mirrors into the upper half for a short' do
+      band = pd.ote(:bearish)
+
+      expect(band[:bottom]).to be_within(0.01).of(161.8)
+      expect(band[:top]).to be_within(0.01).of(179.0)
+    end
+  end
+
+  context 'without a usable range' do
+    it 'answers nil rather than dividing by zero' do
+      empty = described_class.new(nil)
+
+      expect(empty).not_to be_valid
+      expect(empty.zone(100.0)).to be_nil
+      expect(empty.favourable?(100.0, :bullish)).to be(false)
+      expect(empty.ote(:bullish)).to be_nil
+    end
+  end
+end

--- a/spec/services/crypto/smc/structure_spec.rb
+++ b/spec/services/crypto/smc/structure_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Crypto::Smc::Structure do
+  # Up-leg to a pivot high at 110, pullback to a pivot low, then a close back
+  # above 110. The break is bullish and, with no prior trend, is a BOS.
+  let(:bullish_break) do
+    crypto_series([
+                    [100, 101, 99, 100],
+                    [100, 103, 100, 102],
+                    [102, 110, 101, 108],  # pivot high 110 @ index 2
+                    [108, 108, 104, 105],
+                    [105, 106, 100, 101],
+                    [101, 102, 98, 99],    # pivot low 98 @ index 5
+                    [99, 104, 99, 103],
+                    [103, 108, 102, 107],
+                    [107, 113, 106, 112],  # closes above 110 -> bullish break
+                    [112, 114, 110, 113],
+                    [113, 115, 111, 114]
+                  ])
+  end
+
+  it 'reports a bullish BOS when the first break has no trend to contradict' do
+    events = described_class.new(bullish_break, strength: 2).events
+
+    expect(events.size).to eq(1)
+    expect(events.first).to have_attributes(type: :bos, direction: :bullish, level: 110.0)
+  end
+
+  it 'sets the trend from the last event' do
+    expect(described_class.new(bullish_break, strength: 2).trend).to eq(:bullish)
+  end
+
+  it 'requires a close beyond the level, not merely a wick' do
+    # Same path, but the breaking bar wicks to 113 and closes back at 109.
+    wick_only = crypto_series([
+                                [100, 101, 99, 100],
+                                [100, 103, 100, 102],
+                                [102, 110, 101, 108],
+                                [108, 108, 104, 105],
+                                [105, 106, 100, 101],
+                                [101, 102, 98, 99],
+                                [99, 104, 99, 103],
+                                [103, 108, 102, 107],
+                                [107, 113, 106, 109], # wick through 110, close under
+                                [109, 110, 107, 108],
+                                [108, 109, 106, 107]
+                              ])
+
+    expect(described_class.new(wick_only, strength: 2).events).to be_empty
+  end
+
+  it 'calls the counter-trend break a CHoCH' do
+    # Bullish BOS first, then a close below the swing low that follows it.
+    series = crypto_series([
+                             [100, 101, 99, 100],
+                             [100, 103, 100, 102],
+                             [102, 110, 101, 108],
+                             [108, 108, 104, 105],
+                             [105, 106, 100, 101],
+                             [101, 102, 98, 99],
+                             [99, 104, 99, 103],
+                             [103, 108, 102, 107],
+                             [107, 113, 106, 112],  # BOS bullish through 110
+                             [112, 116, 111, 115],
+                             [115, 118, 112, 113],  # pivot high 118
+                             [113, 114, 108, 109],
+                             [109, 110, 105, 106],  # pivot low 105
+                             [106, 111, 105, 110],
+                             [110, 112, 108, 111],
+                             [111, 112, 103, 104],  # closes below 105 -> CHoCH bearish
+                             [104, 105, 100, 101],
+                             [101, 103, 99, 100]
+                           ])
+
+    events = described_class.new(series, strength: 2).events
+
+    expect(events.map { |e| [e.type, e.direction] }).to include(%i[bos bullish], %i[choch bearish])
+    expect(events.last.direction).to eq(:bearish)
+  end
+
+  describe '#recent_event' do
+    it 'ignores an event older than the lookback' do
+      structure = described_class.new(bullish_break, strength: 2)
+
+      expect(structure.recent_event(direction: :bullish, lookback: 10)).to be_present
+      expect(structure.recent_event(direction: :bullish, lookback: 1)).to be_nil
+    end
+  end
+
+  describe '#dealing_range' do
+    it 'spans the recent swing high and low' do
+      range = described_class.new(bullish_break, strength: 2).dealing_range
+
+      expect(range[:high]).to eq(110.0)
+      expect(range[:low]).to eq(98.0)
+    end
+  end
+
+  it 'returns no events when the series is too short to hold a pivot' do
+    expect(described_class.new(crypto_series([[100, 101, 99, 100]]), strength: 2).events).to be_empty
+  end
+end

--- a/spec/support/crypto_candles.rb
+++ b/spec/support/crypto_candles.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Builders for the crypto SMC specs.
+#
+# The detectors care about the *shape* of a price path, so the specs describe
+# bars as plain [open, high, low, close] tuples and let this helper stamp
+# sequential timestamps on them. Anything hand-built stays readable as a chart.
+module CryptoCandleHelper
+  BASE_TIME = Time.zone.parse('2026-01-05 00:00:00 UTC')
+
+  # @param bars [Array<Array(Numeric, Numeric, Numeric, Numeric)>] o, h, l, c
+  def crypto_series(bars, symbol: 'TESTUSDT', timeframe: '5m', interval: 300)
+    candles = bars.each_with_index.map do |(o, h, l, c), i|
+      Crypto::Candle.new(ts: BASE_TIME + (i * interval), open: o, high: h, low: l, close: c, volume: 100)
+    end
+
+    Crypto::Series.new(symbol: symbol, timeframe: timeframe, candles: candles)
+  end
+
+  # Binance-shaped kline rows, for client and parsing specs.
+  def binance_rows(bars, start_ms: BASE_TIME.to_i * 1000, interval_ms: 300_000)
+    bars.each_with_index.map do |(o, h, l, c), i|
+      [start_ms + (i * interval_ms), o.to_s, h.to_s, l.to_s, c.to_s, '1000.5',
+       start_ms + ((i + 1) * interval_ms) - 1, '0', 10, '0', '0', '0']
+    end
+  end
+
+  # A zig-zag with a configurable per-leg drift: enough swings for structure to
+  # have something to break, without hand-writing eighty bars.
+  #
+  # @param legs [Integer] number of up/down leg pairs
+  # @param drift [Float] added to each leg's start, so the zig-zag trends
+  def zigzag_bars(legs: 6, start: 100.0, amplitude: 4.0, drift: 0.0, step: 4)
+    bars = []
+    price = start
+
+    legs.times do |leg|
+      up = leg.even?
+      step.times do
+        delta = (up ? amplitude : -amplitude) / step
+        o = price
+        c = o + delta
+        bars << [o, [o, c].max + 0.2, [o, c].min - 0.2, c]
+        price = c
+      end
+      price += drift
+    end
+
+    bars
+  end
+end
+
+RSpec.configure do |config|
+  config.include CryptoCandleHelper
+end


### PR DESCRIPTION
Analysis-only scanner over Binance USD-M futures market data. Reads Smart
Money Concepts / ICT structure top-down across 1d, 4h, 1h, 15m and 5m
(execution) and notifies Telegram only when a LONG or SHORT setup clears
every gate. Places no orders, holds no credentials, persists nothing.

The DhanHQ path is untouched: no existing service, model or job is modified,
and the only edits to existing files are additive (README, .env.example, and
recurring.yml, which was entirely commented out).

Analysis layer (app/services/crypto/smc):
- Structure: BOS and CHoCH confirmed on closes, never wicks. Pivots are only
  usable from their confirmation bar, so the walk cannot break structure
  against a level the market had not yet formed.
- OrderBlocks: detection starts from a structure break and walks backwards
  into the impulse, so a candle qualifies only if displacement followed it.
- FairValueGaps: three-candle imbalances, ATR-filtered, tapped vs. filled
  tracked separately.
- Liquidity: equal-high/low pools and sweeps of the most recent pivot.
- PremiumDiscount: dealing-range position plus the 0.618-0.79 OTE band.
- PriceAction: displacement, engulfing, rejection wicks.

SetupDetector weights thirteen confluences to a normalised score and applies
hard gates: a 5m trigger is mandatory, 1d and 4h must not both oppose, score
>= 62, R:R >= 1.8, and the stop must fit inside 2.5x the 15m ATR. Direction
is a weighted vote rather than a gate so a real 4h reversal is not discarded
for disagreeing with the daily trend it is ending.

Delivery:
- AlertDispatcher suppresses repeats through an in-process hash plus a
  shared Rails.cache entry, since the scheduled job and the stream runner
  dispatch from different processes.
- KlineStream scans on candle close (k.x) over one combined socket, and
  carries a 5-minute safety-net sweep because this app has no scheduler.
- SmcScanJob subclasses ActiveJob::Base, not ApplicationJob: the latter mints
  a DhanHQ token before every perform and re-raises, which would take the
  crypto scanner down whenever the Dhan session lapsed. Retries are off so a
  retry cannot alert on a candle that has since been replaced.

Crypto::Candle is separate from the app's Candle, which rounds prices to an
NSE 0.05 tick and truncates volume to an integer.

108 specs covering the primitives, detector gating, dispatcher dedup, client
error handling and stream frame parsing. Full suite green, rubocop clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C5T3QMWXFQ2aQDAcw1jkHB