### PR TITLE
Trade the index watchlist into the paper book

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,38 @@ GLOBAL_ALLOC_PCT=20
 # not by env vars.
 PAPER_TRADING=false
 
+# Starting capital for the simulated book, in rupees. Read only when the
+# account row is first created; `rails live:paper_capital CAPITAL=100000`
+# applies a change to a book that already exists (and clears it).
+PAPER_CAPITAL=100000
+
+# ── Index watchlist scanner ──────────────────────────────────────────────
+# The autonomous side of the app: `rails live:paper_engine` runs the market
+# feed and re-runs Market::AnalysisUpdater on a timer, and a high-confluence
+# signal becomes an Alert on the normal pipeline (AlertProcessors::Index →
+# Orders::Gateway), so strike selection, sizing and risk are unchanged. The
+# engine refuses to start unless PAPER_TRADING is on.
+#
+# Indices to watch, comma separated. Drives both the analysis and the trading.
+INDEX_WATCHLIST=NIFTY,BANKNIFTY,SENSEX
+
+# Master switch for turning those signals into orders. With it off the scan
+# still runs and still notifies Telegram; it just never places anything.
+INDEX_WATCHLIST_TRADING=false
+
+# Minimum confluence conviction that may trade: medium is 5 of 14 factors
+# agreeing, high is 8. Medium fires several times a session.
+INDEX_WATCHLIST_MIN_LEVEL=high
+
+# Bounds on an unattended loop: entries per symbol per day, and the quiet
+# period after one fires.
+INDEX_WATCHLIST_MAX_TRADES_PER_DAY=3
+INDEX_WATCHLIST_COOLDOWN_MINUTES=30
+
+# How often the engine re-runs the scan. The score is computed on 5-minute
+# candles, so a faster loop re-reads the same candle.
+INDEX_WATCHLIST_SCAN_SECONDS=180
+
 # ── LLM backend ──────────────────────────────────────────────────────────
 # Which service answers chat requests from Openai::ChatRouter (the screener,
 # portfolio/position analysers and market commentary all go through it).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,31 @@ decisions below are settled; each has a failure mode behind it.
   mode — it authorises a real depository debit.
 - Distinct from `DHAN_DRY_RUN`, which is the SDK suppressing requests. Paper
   mode simulates fills, margin, positions and P&L with real charges.
+- **`PAPER_CAPITAL` only applies to a book that does not exist yet.**
+  `PaperAccount.current` reads it on create; re-capitalising a running book on
+  every boot would rewrite the denominator of every P&L figure it has already
+  produced. `rails live:paper_capital CAPITAL=…` applies a change deliberately,
+  and clears the book with it.
+
+## Index watchlist scanner
+
+- **`live:paper_engine` is the autonomous side**, and it holds the feed *and*
+  the scan loop in one process because `Live::TickCache` is process-local: a
+  scanner elsewhere would place orders no tick stream ever fills. It cannot
+  live in Puma either — `WEB_CONCURRENCY=2` forks would each open a socket.
+- **`Market::ConfluenceTrader` is a signal source, not an execution path.** It
+  turns a `ConfluenceDetector` signal into an `Alert` and hands it to
+  `AlertProcessorFactory`, exactly as the webhook does, so strike selection,
+  sizing, risk and exits stay in `AlertProcessors::Index` → `Orders::Gateway`.
+  Anything it needs to decide differently belongs in the processor, not in a
+  parallel path.
+- **The roster is `Market::IndexWatchlist`, not a `Watchlist` row.**
+  `Watchlist`/`WatchlistItem` are the equity universe `Watchlists::RefreshService`
+  rebuilds daily; three indices that change about never do not need a table and
+  a "traded nothing because the row was missing" failure mode.
+- **The engine aborts unless `PAPER_TRADING` is on.** It places orders on its
+  own initiative, so it must never be one env var away from doing that live.
+  See `docs/PAPER_TRADING_INDICES.md`.
 
 ## LLM layer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,14 @@ decisions below are settled; each has a failure mode behind it.
 - **The engine aborts unless `PAPER_TRADING` is on.** It places orders on its
   own initiative, so it must never be one env var away from doing that live.
   See `docs/PAPER_TRADING_INDICES.md`.
+- **`MarketCalendar.market_open?` is the only definition of the session** —
+  weekday, not on the holiday list, 09:15–15:30 IST, converted to IST rather
+  than assumed. `Orders::PlaceOrderGuard`, `Paper::Exchange`,
+  `Mcp::Tools::SystemStatus` and the scanner all delegate to it; they used to
+  each carry a copy, and `Paper::Exchange`'s had drifted to a weekday-only
+  check that accepted orders on market holidays. Don't reintroduce a local
+  copy. `force: true` waives it, which is what lets `Paper::EodSquareOff` close
+  positions after the bell.
 
 ## LLM layer
 

--- a/README.md
+++ b/README.md
@@ -293,11 +293,20 @@ and, in paper mode, the tick stream is what fills resting orders and marks
 positions. The engine refuses to start unless `PAPER_TRADING` is on.
 
 Bounds on the loop: `INDEX_WATCHLIST_MIN_LEVEL` (default `high`, 8 of 14
-confluence factors), a per-symbol `INDEX_WATCHLIST_COOLDOWN_MINUTES`, a
-per-symbol `INDEX_WATCHLIST_MAX_TRADES_PER_DAY`, and an entry window of
-09:20–15:00 IST — nothing new is opened inside the 15:15 square-off. Set
+confluence factors), a per-symbol `INDEX_WATCHLIST_COOLDOWN_MINUTES` and a
+per-symbol `INDEX_WATCHLIST_MAX_TRADES_PER_DAY`. Set
 `INDEX_WATCHLIST_TRADING=false` to keep the feed, the book and the Telegram
 alerts while placing nothing. See `docs/PAPER_TRADING_INDICES.md`.
+
+**Session hours.** `MarketCalendar.market_open?` is the single definition —
+a weekday, not on the holiday list, 09:15–15:30 IST — and every gate reads it:
+`Orders::PlaceOrderGuard` live, `Paper::Exchange` on the paper book, the MCP
+status tool, and the scanner. Entries from the scanner are narrower still,
+09:20–15:00, so nothing new is opened inside the 15:15 square-off. Nothing
+trades at the weekend or on a market holiday. The times are evaluated in IST
+regardless of the host's zone, which matters on Render (UTC). The one exception
+is a `force: true` order, which waives the check so the EOD square-off can
+close positions after the bell.
 
 ### Alert routing by asset class
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,13 @@ bin/rails live:paper_book    # positions, working orders, P&L and charges
 bin/rails live:paper_eod     # square off intraday positions now
 bin/rails live:paper_roll    # roll the book onto the current session
 bin/rails live:paper_reset   # reset the book to its starting capital
+bin/rails live:paper_capital CAPITAL=100000   # set the book's capital (clears it)
 ```
+
+`PAPER_CAPITAL` sets the starting capital when the book is first created; after
+that it is fixed, because re-capitalising a running book would rewrite the
+denominator of every P&L figure it has already produced. Use
+`live:paper_capital` to change it deliberately.
 
 This is a step beyond the SDK's `DHAN_DRY_RUN`, which suppresses the request and
 returns a `DRYRUN-…` id without modelling the outcome. `Paper::Exchange` is a
@@ -268,6 +274,30 @@ impact for sizing studies.
 approximation rather than SPAN. It is conservative for option buying and
 **understates naked option selling**, where real SPAN is far higher — don't use
 paper margin to size a short-vol strategy.
+
+### Trading the index watchlist unattended
+
+The app is signal-driven, so without a sender it sits idle. `live:paper_engine`
+is the sender: one process holding the market feed *and* a scan loop over
+`INDEX_WATCHLIST` (default `NIFTY,BANKNIFTY,SENSEX`). A high-confluence signal
+becomes an `Alert` on the normal pipeline — `AlertProcessors::Index` →
+`Orders::Gateway` — so strike selection, sizing, risk and exits are unchanged.
+
+```bash
+PAPER_TRADING=true PAPER_CAPITAL=100000 INDEX_WATCHLIST_TRADING=true \
+  bin/rails live:paper_engine
+```
+
+Feed and scan share a process on purpose: `Live::TickCache` is process-local
+and, in paper mode, the tick stream is what fills resting orders and marks
+positions. The engine refuses to start unless `PAPER_TRADING` is on.
+
+Bounds on the loop: `INDEX_WATCHLIST_MIN_LEVEL` (default `high`, 8 of 14
+confluence factors), a per-symbol `INDEX_WATCHLIST_COOLDOWN_MINUTES`, a
+per-symbol `INDEX_WATCHLIST_MAX_TRADES_PER_DAY`, and an entry window of
+09:20–15:00 IST — nothing new is opened inside the 15:15 square-off. Set
+`INDEX_WATCHLIST_TRADING=false` to keep the feed, the book and the Telegram
+alerts while placing nothing. See `docs/PAPER_TRADING_INDICES.md`.
 
 ### Alert routing by asset class
 

--- a/app/models/paper_account.rb
+++ b/app/models/paper_account.rb
@@ -25,13 +25,48 @@ class PaperAccount < ApplicationRecord
     'market_hours_enforced' => true
   }.freeze
 
+  # Starting capital when the book is first created, in rupees.
+  #
+  # `PAPER_CAPITAL` only decides what a *new* book starts with — an account row
+  # already in the database keeps its capital, because silently re-capitalising
+  # a running book would rewrite the denominator of every P&L number it has
+  # produced so far. Use {.recapitalize!} (or `rails live:paper_capital`) to
+  # apply a new figure deliberately.
+  DEFAULT_CAPITAL = 1_000_000
+
+  # @return [BigDecimal] configured starting capital, falling back to the
+  #   default when PAPER_CAPITAL is unset or not a positive number
+  def self.configured_capital
+    configured = ENV.fetch('PAPER_CAPITAL', nil).to_s.strip.delete('_,').to_d
+    configured.positive? ? configured : DEFAULT_CAPITAL.to_d
+  rescue ArgumentError
+    DEFAULT_CAPITAL.to_d
+  end
+
   # @return [PaperAccount] the single account, created on first use
   def self.current
     first || create!(
-      available_balance: 1_000_000,
-      initial_capital: 1_000_000,
+      available_balance: configured_capital,
+      initial_capital: configured_capital,
       config: DEFAULT_CONFIG.dup
     )
+  end
+
+  # Sets the book's capital and resets it to that figure. Destructive by
+  # design: open positions and orders go with it, because a book holding
+  # positions sized against the old capital is not comparable to one starting
+  # fresh at the new figure.
+  #
+  # @param capital [Numeric, nil] defaults to PAPER_CAPITAL
+  # @return [PaperAccount]
+  def self.recapitalize!(capital = nil)
+    amount = (capital || configured_capital).to_d
+    raise ArgumentError, "capital must be positive, got #{amount}" unless amount.positive?
+
+    account = current
+    account.update!(initial_capital: amount)
+    account.reset!
+    account
   end
 
   # @return [Hash] config with defaults filled in

--- a/app/services/market/analysis_updater.rb
+++ b/app/services/market/analysis_updater.rb
@@ -4,11 +4,14 @@ module Market
   # Service for updating technical analysis (ATR, Trend, Confluence) for key indices.
   class AnalysisUpdater < ApplicationService
     INTERVAL  = '5' # 5-minute candles
-    SYMBOLS   = %w[NIFTY BANKNIFTY SENSEX].freeze
+    # Kept for callers that reference it; the roster itself now comes from
+    # Market::IndexWatchlist so INDEX_WATCHLIST drives analysis and trading
+    # from one place rather than two lists that can disagree.
+    SYMBOLS   = IndexWatchlist::DEFAULT_SYMBOLS
 
     def call
       candle_map = {}
-      SYMBOLS.each do |sym|
+      IndexWatchlist.symbols.each do |sym|
         candles = update_symbol(sym)
         candle_map[sym] = candles if candles.present?
       end
@@ -65,11 +68,31 @@ module Market
       series.hlc # Returns [ {high:, low:, close:, date_time:}, ... ]
     end
 
+    # The notifier and the trader are two independent consumers of one signal:
+    # a failing Telegram token must not stop an entry, and a declined entry
+    # must not silence the alert. Hence the separate rescues.
     def detect_confluence(symbol, candles)
       signal = Market::ConfluenceDetector.call(symbol: symbol, candles: candles)
-      Market::ConfluenceNotifier.call(signal: signal)
+      return if signal.nil?
+
+      notify_confluence(signal)
+      trade_confluence(signal)
     rescue StandardError => e
       log_error("Confluence #{symbol} – #{e.class}: #{e.message}")
+    end
+
+    def notify_confluence(signal)
+      Market::ConfluenceNotifier.call(signal: signal)
+    rescue StandardError => e
+      log_error("Confluence notify #{signal.symbol} – #{e.class}: #{e.message}")
+    end
+
+    # Gated on INDEX_WATCHLIST_TRADING inside the trader, so this call is inert
+    # until that is deliberately switched on.
+    def trade_confluence(signal)
+      Market::ConfluenceTrader.call(signal: signal)
+    rescue StandardError => e
+      log_error("Confluence trade #{signal.symbol} – #{e.class}: #{e.message}")
     end
 
     # --- ATR (simple Wilder’s) ----------------------------------------------

--- a/app/services/market/confluence_trader.rb
+++ b/app/services/market/confluence_trader.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module Market
+  # Turns a {Market::ConfluenceDetector::ConfluenceSignal} into a tradable
+  # signal on the existing pipeline.
+  #
+  # This is a signal *source*, not a second execution path. It builds an Alert
+  # and hands it to `AlertProcessorFactory`, exactly as the TradingView webhook
+  # and {TelegramBot::ManualSignalTrigger} do, so strike selection, sizing,
+  # risk and placement all stay in `AlertProcessors::Index` →
+  # `Orders::Gateway`. Nothing here talks to a broker or to `Paper::Exchange`;
+  # whether the resulting order is simulated is the gateway's decision, made
+  # from `PAPER_TRADING`.
+  #
+  # ## Gates, in the order they are applied
+  #
+  # 1. `INDEX_WATCHLIST_TRADING` — off by default.
+  # 2. The symbol is on {Market::IndexWatchlist}.
+  # 3. The signal clears `INDEX_WATCHLIST_MIN_LEVEL` (default :high, 8/14).
+  # 4. It is a trading day and we are inside the entry window.
+  # 5. No trade on this symbol within `INDEX_WATCHLIST_COOLDOWN_MINUTES`.
+  # 6. Today's entries for this symbol are under
+  #    `INDEX_WATCHLIST_MAX_TRADES_PER_DAY`.
+  #
+  # Gates 5 and 6 are belt and braces over `ConfluenceDetector`'s own
+  # state-change and cooldown logic, which is keyed on the signal rather than
+  # on an order: a process restart repopulates its cache from scratch, and a
+  # detector that started flip-flopping would otherwise trade every flip.
+  class ConfluenceTrader < ApplicationService
+    STRATEGY_NAME = 'Index Confluence Scanner'
+    ZONE = 'Asia/Kolkata'
+
+    # No entries in the first minutes — the opening range is noise and the
+    # 5-minute candles the score is computed on have barely formed.
+    ENTRY_OPENS_AT = { hour: 9, min: 20 }.freeze
+    # Nothing new after this: Paper::EodSquareOff (and the broker, live) closes
+    # INTRADAY at 15:15, so a later entry buys a position to be closed at once.
+    ENTRY_CLOSES_AT = { hour: 15, min: 0 }.freeze
+
+    # A bullish score buys a Call, a bearish one buys a Put — the mapping
+    # AlertProcessors::Index::SIGNAL_TO_OPTION expects.
+    BIAS_TO_SIGNAL = { bullish: 'long_entry', bearish: 'short_entry' }.freeze
+
+    def initialize(signal:)
+      @signal = signal
+    end
+
+    # @return [Alert, nil] the alert that was processed, or nil when a gate
+    #   declined the signal
+    def call
+      return nil if @signal.nil?
+      return nil unless tradable?
+
+      instrument = IndexWatchlist.instrument_for(symbol)
+      return log_skip('instrument not found in the index segment') if instrument.nil?
+
+      alert = create_alert!(instrument)
+      log_info("#{symbol} #{@signal.bias} #{@signal.level} (#{@signal.net_score}/#{@signal.max_score}) " \
+               "→ alert ##{alert.id} #{signal_type}")
+
+      AlertProcessorFactory.build(alert).call
+      mark_traded
+      alert
+    rescue StandardError => e
+      log_error("#{symbol} – #{e.class}: #{e.message}")
+      nil
+    end
+
+    private
+
+    def symbol
+      @symbol ||= @signal.symbol.to_s.upcase
+    end
+
+    def signal_type
+      BIAS_TO_SIGNAL[@signal.bias.to_s.to_sym]
+    end
+
+    # ── Gates ────────────────────────────────────────────────────────────────
+
+    def tradable?
+      return log_skip('INDEX_WATCHLIST_TRADING is off') unless IndexWatchlist.trading_enabled?
+      return log_skip('not on the index watchlist') unless IndexWatchlist.include?(symbol)
+      return log_skip("bias #{@signal.bias} is not tradable") if signal_type.nil?
+      return log_skip("level #{@signal.level} below #{IndexWatchlist.min_level}") unless level_ok?
+      return log_skip('outside the entry window') unless within_entry_window?
+      return log_skip('cooling down since the last entry') if cooldown_active?
+      return log_skip("daily cap of #{IndexWatchlist.max_trades_per_day} reached") if daily_cap_reached?
+
+      true
+    end
+
+    def level_ok?
+      IndexWatchlist.level_tradable?(@signal.level)
+    end
+
+    def within_entry_window?
+      now = Time.current.in_time_zone(ZONE)
+      return false unless MarketCalendar.trading_day?(now.to_date)
+
+      now.between?(now.change(**ENTRY_OPENS_AT), now.change(**ENTRY_CLOSES_AT))
+    end
+
+    def cooldown_active?
+      Rails.cache.read(cooldown_key).present?
+    end
+
+    def mark_traded
+      Rails.cache.write(cooldown_key, Time.current.iso8601, expires_in: IndexWatchlist.cooldown)
+    end
+
+    def cooldown_key
+      "index_watchlist:last_trade:#{symbol}"
+    end
+
+    # Counts entries this scanner actually put into the pipeline today. A
+    # `skipped` alert never reached the broker — the processor declined it on
+    # its own analysis — so it does not consume the day's budget, and a
+    # `failed` one placed nothing either.
+    def daily_cap_reached?
+      todays_trades = Alert.where(ticker: symbol, strategy_name: STRATEGY_NAME)
+        .where(created_at: Time.current.in_time_zone(ZONE).all_day)
+        .where.not(status: %w[skipped failed])
+        .count
+
+      todays_trades >= IndexWatchlist.max_trades_per_day
+    end
+
+    # ── Alert construction ───────────────────────────────────────────────────
+
+    def create_alert!(instrument)
+      instrument.alerts.create!(
+        ticker: symbol,
+        instrument_type: 'index',
+        exchange: IndexWatchlist.exchange_for(symbol).to_s.upcase,
+        order_type: 'market',
+        action: 'buy',
+        signal_type: signal_type,
+        strategy_type: 'intraday',
+        strategy_name: STRATEGY_NAME,
+        strategy_id: SecureRandom.uuid,
+        current_position: 'flat',
+        previous_position: 'flat',
+        current_price: entry_price(instrument),
+        chart_interval: '5',
+        time: Time.current.iso8601,
+        metadata: signal_metadata
+      )
+    end
+
+    # The signal's own close is the price the score was computed on, which is
+    # the honest record of why the trade fired. It is a spot index level, not
+    # an option premium — `AlertProcessors::Index` prices the contract itself.
+    def entry_price(instrument)
+      price = @signal.close.to_f
+      return price if price.positive?
+
+      instrument.ltp.to_f
+    rescue StandardError
+      0.0
+    end
+
+    def signal_metadata
+      {
+        'triggered_by' => 'index_confluence_scanner',
+        'bias' => @signal.bias.to_s,
+        'level' => @signal.level.to_s,
+        'net_score' => @signal.net_score,
+        'max_score' => @signal.max_score,
+        'atr' => @signal.atr&.round(2),
+        'factors' => Array(@signal.factors).map { |f| { 'name' => f.name, 'value' => f.value, 'note' => f.note } }
+      }
+    end
+
+    # Gates return nil through this so `tradable?` reads as a list of reasons.
+    def log_skip(reason)
+      log_info("#{symbol} signal not traded – #{reason}")
+      nil
+    end
+  end
+end

--- a/app/services/market/confluence_trader.rb
+++ b/app/services/market/confluence_trader.rb
@@ -96,9 +96,13 @@ module Market
       IndexWatchlist.level_tradable?(@signal.level)
     end
 
+    # Two conditions, not one. `MarketCalendar.market_open?` is the session
+    # itself — weekday, not a listed holiday, 09:15–15:30 IST — and the entry
+    # window is a strictly narrower slice of it. Checking both means a change
+    # to the session definition can never let an entry fall outside it.
     def within_entry_window?
       now = Time.current.in_time_zone(ZONE)
-      return false unless MarketCalendar.trading_day?(now.to_date)
+      return false unless MarketCalendar.market_open?(now)
 
       now.between?(now.change(**ENTRY_OPENS_AT), now.change(**ENTRY_CLOSES_AT))
     end

--- a/app/services/market/index_watchlist.rb
+++ b/app/services/market/index_watchlist.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Market
+  # The roster of indices the autonomous scanner watches, and the switches that
+  # decide whether a confluence signal on one of them is allowed to trade.
+  #
+  # This is deliberately a *roster*, not a `Watchlist` record. `Watchlist` /
+  # `WatchlistItem` hold the equity universe that `Watchlists::RefreshService`
+  # rebuilds from a scan — 120-odd rows that churn daily. The index set is three
+  # symbols that change about never, so a table would add a migration, a seed
+  # and a failure mode ("scanner traded nothing because the watchlist row was
+  # missing") to answer a question a constant answers.
+  #
+  # Symbols must exist in the index segment of the scrip master, which
+  # `db/seeds/index_instruments.csv` carries — see the instrument-master notes
+  # in CLAUDE.md. A symbol that does not resolve is skipped and logged rather
+  # than raising, so one bad entry in `INDEX_WATCHLIST` cannot stop the others
+  # from trading.
+  class IndexWatchlist
+    DEFAULT_SYMBOLS = %w[NIFTY BANKNIFTY SENSEX].freeze
+
+    # Which exchange each index lists on. Anything absent is assumed NSE, which
+    # is right for every index Dhan carries except the BSE pair.
+    EXCHANGES = {
+      'NIFTY' => :nse,
+      'BANKNIFTY' => :nse,
+      'FINNIFTY' => :nse,
+      'MIDCPNIFTY' => :nse,
+      'SENSEX' => :bse,
+      'BANKEX' => :bse
+    }.freeze
+
+    # Confluence levels in ascending order of conviction. `ConfluenceDetector`
+    # emits :medium at |score| >= 5 and :high at |score| >= 8 out of 14.
+    LEVEL_RANK = { none: 0, medium: 1, high: 2 }.freeze
+
+    class << self
+      # @return [Array<String>] symbols to watch, upper-cased and de-duplicated
+      def symbols
+        configured = ENV.fetch('INDEX_WATCHLIST', '').to_s.split(',').map { |s| s.strip.upcase }.reject(&:empty?)
+        configured.presence&.uniq || DEFAULT_SYMBOLS
+      end
+
+      # @param symbol [String]
+      # @return [Boolean]
+      def include?(symbol)
+        symbols.include?(symbol.to_s.upcase)
+      end
+
+      # @param symbol [String]
+      # @return [Symbol] :nse or :bse
+      def exchange_for(symbol)
+        EXCHANGES.fetch(symbol.to_s.upcase, :nse)
+      end
+
+      # @param symbol [String]
+      # @return [Instrument, nil] the index-segment instrument, or nil when the
+      #   scrip master has not been seeded for it
+      def instrument_for(symbol)
+        Instrument.segment_index.find_by(underlying_symbol: symbol.to_s.upcase)
+      end
+
+      # @return [Array<Instrument>] every watched index that resolves
+      def instruments
+        symbols.filter_map do |symbol|
+          instrument = instrument_for(symbol)
+          Rails.logger.warn("[IndexWatchlist] #{symbol} not found in the index segment; skipping") if instrument.nil?
+          instrument
+        end
+      end
+
+      # The master switch for autonomous trading off this watchlist. Off by
+      # default: importing this file must never, on its own, make the app
+      # place orders.
+      #
+      # @return [Boolean]
+      def trading_enabled?
+        ENV.fetch('INDEX_WATCHLIST_TRADING', 'false').to_s.casecmp('true').zero?
+      end
+
+      # Minimum confluence conviction that may trade. Defaults to :high — a
+      # :medium signal (5/14) is worth a Telegram message, not capital.
+      #
+      # @return [Symbol] :medium or :high
+      def min_level
+        level = ENV.fetch('INDEX_WATCHLIST_MIN_LEVEL', 'high').to_s.downcase.to_sym
+        LEVEL_RANK.key?(level) && level != :none ? level : :high
+      end
+
+      # @param level [Symbol] the signal's level
+      # @return [Boolean] whether it clears {min_level}
+      def level_tradable?(level)
+        LEVEL_RANK.fetch(level.to_s.to_sym, 0) >= LEVEL_RANK.fetch(min_level)
+      end
+
+      # Per-symbol quiet period after a trade fires. `ConfluenceDetector` has
+      # its own 45-minute cooldown, but that one is keyed on the *signal* and
+      # resets when the process restarts mid-session; this one is keyed on an
+      # order actually being placed.
+      #
+      # @return [ActiveSupport::Duration]
+      def cooldown
+        ENV.fetch('INDEX_WATCHLIST_COOLDOWN_MINUTES', '30').to_i.clamp(1, 1_440).minutes
+      end
+
+      # Hard stop on how many entries the scanner may fire per symbol per day,
+      # whatever the signal says. An unattended loop with a broken gate should
+      # cost a bounded number of trades, not a session's worth.
+      #
+      # @return [Integer]
+      def max_trades_per_day
+        ENV.fetch('INDEX_WATCHLIST_MAX_TRADES_PER_DAY', '3').to_i.clamp(1, 50)
+      end
+
+      # How often {Market::AnalysisUpdater} is re-run by `live:paper_engine`.
+      # Matches the 5-minute candles the analysis is computed on; a faster loop
+      # re-reads the same candle and burns rate limit.
+      #
+      # @return [Integer] seconds
+      def scan_interval
+        ENV.fetch('INDEX_WATCHLIST_SCAN_SECONDS', '180').to_i.clamp(30, 3_600)
+      end
+    end
+  end
+end

--- a/app/services/market_calendar.rb
+++ b/app/services/market_calendar.rb
@@ -31,11 +31,38 @@ module MarketCalendar
     Date.new(2026, 12, 25)  # Christmas
   ].freeze
 
+  # NSE/BSE regular session, in IST.
+  ZONE = 'Asia/Kolkata'.freeze
+  SESSION_OPEN_MINUTES = (9 * 60) + 15
+  SESSION_CLOSE_MINUTES = (15 * 60) + 30
+
   def self.trading_day?(date)
     return false unless date.respond_to?(:on_weekday?)
 
     date = date.to_date if date.respond_to?(:to_date)
     date.on_weekday? && MARKET_HOLIDAYS.exclude?(date)
+  end
+
+  # The one answer to "is the market open right now". Weekday, not a listed
+  # holiday, and inside 09:15–15:30 IST.
+  #
+  # Everything that gates on the session reads this — Orders::PlaceOrderGuard
+  # on the live path, Paper::Exchange on the simulated one, the MCP status
+  # tool. They each carried their own copy of these two rules, and one of them
+  # (Paper::Exchange) had drifted: it checked the weekday but not the holiday
+  # list, so a paper order placed on Gandhi Jayanti was accepted.
+  #
+  # The time is converted to IST rather than assumed to be in it, so this is
+  # correct on a UTC host regardless of what the caller passes.
+  #
+  # @param time [Time, ActiveSupport::TimeWithZone]
+  # @return [Boolean]
+  def self.market_open?(time = Time.current)
+    ist = time.respond_to?(:in_time_zone) ? time.in_time_zone(ZONE) : Time.current.in_time_zone(ZONE)
+    return false unless trading_day?(ist.to_date)
+
+    minutes = (ist.hour * 60) + ist.min
+    minutes >= SESSION_OPEN_MINUTES && minutes <= SESSION_CLOSE_MINUTES
   end
 
   # Returns the most recent trading day on or before +from+.

--- a/app/services/mcp/tools/system_status.rb
+++ b/app/services/mcp/tools/system_status.rb
@@ -45,10 +45,7 @@ module Mcp
         private
 
         def market_open?(time)
-          return false unless MarketCalendar.trading_day?(time.to_date)
-
-          minutes = (time.hour * 60) + time.min
-          minutes >= (9 * 60) + 15 && minutes <= (15 * 60) + 30
+          MarketCalendar.market_open?(time)
         end
       end
     end

--- a/app/services/orders/place_order_guard.rb
+++ b/app/services/orders/place_order_guard.rb
@@ -42,10 +42,7 @@ module Orders
     end
 
     def market_open?(time)
-      return false unless MarketCalendar.trading_day?(time.to_date)
-
-      minutes = (time.hour * 60) + time.min
-      minutes >= (9 * 60) + 15 && minutes <= (15 * 60) + 30
+      MarketCalendar.market_open?(time)
     end
 
     def resolve_derivative!

--- a/app/services/paper/exchange.rb
+++ b/app/services/paper/exchange.rb
@@ -167,11 +167,11 @@ module Paper
       settings['market_hours_enforced'].to_s == 'true' || settings['market_hours_enforced'] == true
     end
 
+    # Weekday, not a market holiday, 09:15–15:30 IST. The local copy this used
+    # to carry checked the weekday but not the holiday list, so an order placed
+    # on a weekday holiday was accepted and filled against a stale price.
     def market_open?
-      return MarketCalendar.market_open? if defined?(MarketCalendar) && MarketCalendar.respond_to?(:market_open?)
-
-      now = Time.current.in_time_zone('Asia/Kolkata')
-      now.on_weekday? && now.between?(now.change(hour: 9, min: 15), now.change(hour: 15, min: 30))
+      MarketCalendar.market_open?
     end
 
     # ── Placement ───────────────────────────────────────────────────────

--- a/docs/PAPER_TRADING_INDICES.md
+++ b/docs/PAPER_TRADING_INDICES.md
@@ -1,0 +1,145 @@
+# Paper trading the index watchlist
+
+The app is signal-driven: something has to *send* a signal before anything
+trades. Until now the only senders were the TradingView webhook and the
+Telegram commands, so a deployment with nobody pushing alerts sat idle no
+matter what the trading flags said.
+
+This adds a third sender that runs on its own — a scan loop over a watchlist of
+indices — and points the whole thing at the simulated book.
+
+## The shape of it
+
+```
+live:paper_engine (one worker process)
+  │
+  ├─ Live::MarketFeedHub ── ticks ─→ Live::TickCache
+  │                              └─→ Paper::Exchange.process_tick
+  │                                    fills resting orders, marks positions,
+  │                                    drives DayRollover / EodSquareOff
+  │
+  └─ every INDEX_WATCHLIST_SCAN_SECONDS, during the session:
+       Market::AnalysisUpdater
+         └─ per symbol: fetch 5m candles → Market::ConfluenceDetector
+              ├─ Market::ConfluenceNotifier  → Telegram (unchanged)
+              └─ Market::ConfluenceTrader    → Alert
+                   └─ AlertProcessorFactory → AlertProcessors::Index
+                        └─ Orders::Gateway → Paper::Broker → Paper::Exchange
+```
+
+`ConfluenceTrader` is a signal *source*, not a second execution path. It builds
+an `Alert` and hands it to `AlertProcessorFactory` exactly as the webhook does,
+so strike selection, affordability, sizing, super-order legs, risk management
+and exits are the code that was already there and already tested. Nothing in
+the new code talks to a broker or to `Paper::Exchange` — whether the order is
+simulated stays the gateway's decision, read from `PAPER_TRADING`.
+
+## Why one process
+
+`Live::TickCache` is a process-local Hash, and that is deliberate (see the
+measurement in `CLAUDE.md`). In paper mode the tick stream is the matching
+engine's clock: it fills resting orders, marks positions, trails super-order
+stops, and lazily runs `Paper::DayRollover` and `Paper::EodSquareOff`. Split
+the scanner and the feed across two processes and the scanner places orders
+that nothing ever fills.
+
+The web service cannot host the feed either — Puma runs `WEB_CONCURRENCY=2`
+forks and each would open its own WebSocket to Dhan. Hence a dedicated worker
+that owns both halves.
+
+The web service still has `PAPER_TRADING=true` so that a TradingView webhook or
+a Telegram signal books into the *same* paper account rather than being dropped
+by `PLACE_ORDER=false`. Orders it places rest in the database until the engine's
+tick loop fills them, which works because `Paper::Exchange.process_tick` reads
+the book from the database rather than from memory.
+
+## The gates
+
+`ConfluenceTrader` applies these in order, and logs the reason when it declines:
+
+| Gate | Env | Default |
+|---|---|---|
+| Master switch | `INDEX_WATCHLIST_TRADING` | `false` |
+| Symbol is on the roster | `INDEX_WATCHLIST` | `NIFTY,BANKNIFTY,SENSEX` |
+| Conviction floor | `INDEX_WATCHLIST_MIN_LEVEL` | `high` (8 of 14 factors) |
+| Trading day, 09:20–15:00 IST | — | — |
+| Per-symbol quiet period | `INDEX_WATCHLIST_COOLDOWN_MINUTES` | `30` |
+| Per-symbol daily cap | `INDEX_WATCHLIST_MAX_TRADES_PER_DAY` | `3` |
+
+The window closes at 15:00 because `Paper::EodSquareOff` closes INTRADAY at
+15:15 — a 15:05 entry would be bought and closed within ten minutes. It opens
+at 09:20 because the opening range is noise and the 5-minute candles the score
+is computed on have barely formed.
+
+The cooldown and the daily cap are belt and braces over `ConfluenceDetector`'s
+own 45-minute cooldown and state-change gate. That one is keyed on the *signal*
+and lives in `Rails.cache`, so a process restart mid-session repopulates it from
+scratch; these are keyed on an order actually being placed.
+
+A `skipped` or `failed` alert does not consume the daily budget — the processor
+declined it on its own analysis and nothing was placed.
+
+## Capital
+
+`PAPER_CAPITAL` sets the book's starting capital in rupees. It is read **only
+when the account row is first created**: silently re-capitalising a running
+book on every boot would rewrite the denominator of every P&L number it has
+already produced.
+
+To change the capital of a book that already exists:
+
+```bash
+rails live:paper_capital CAPITAL=100000
+```
+
+That is destructive by design — it clears positions and orders, because a book
+holding positions sized against the old capital is not comparable to one
+starting fresh at the new figure.
+
+The deployment sets `PAPER_CAPITAL=100000` (₹1 lakh). At that balance the
+capital bands in the README put allocation at 30%, risk per trade at 5% and the
+daily loss cap at 5%, so the sizing the index processor does is unchanged — it
+just works from a smaller number.
+
+## Running it
+
+Locally:
+
+```bash
+PAPER_TRADING=true PAPER_CAPITAL=100000 INDEX_WATCHLIST_TRADING=true \
+  rails live:paper_engine
+```
+
+The engine refuses to start unless `PAPER_TRADING` is on — it places orders on
+its own initiative and must never be one environment variable away from doing
+that live. `PAPER_ENGINE_ALLOW_LIVE=true` is the deliberate override and is set
+nowhere in this repo.
+
+Inspecting the book, from any process:
+
+```bash
+rails live:paper_book      # positions, working orders, P&L summary
+rails live:paper_eod       # force the 15:15 square-off
+rails live:paper_roll      # force the day rollover
+rails live:paper_reset     # back to starting capital
+```
+
+## Turning it off
+
+Set `INDEX_WATCHLIST_TRADING=false` on the engine worker. The feed, the book,
+the analysis and the Telegram alerts all keep running; the scanner simply stops
+placing anything. Suspending the worker stops the scan and the fills, but any
+open paper position stays in the database and is picked up when it comes back.
+
+## What did not change
+
+- No new order path. `Orders::Gateway` is still the only way an order is
+  placed, and `PLACE_ORDER` / `LIVE_TRADING` are still `false` everywhere.
+- No scheduler. `config/recurring.yml` is still empty and `config/schedule.rb`
+  is still commented out; the engine's loop is its own clock, like
+  `crypto:stream`.
+- `Watchlist` / `WatchlistItem` still hold the equity universe that
+  `Watchlists::RefreshService` rebuilds. The index roster is a constant plus an
+  env var, because three symbols that change about never do not need a table, a
+  migration and a "scanner traded nothing because the row was missing" failure
+  mode.

--- a/docs/PAPER_TRADING_INDICES.md
+++ b/docs/PAPER_TRADING_INDICES.md
@@ -71,6 +71,40 @@ The window closes at 15:00 because `Paper::EodSquareOff` closes INTRADAY at
 at 09:20 because the opening range is noise and the 5-minute candles the score
 is computed on have barely formed.
 
+## When it is allowed to trade
+
+`MarketCalendar.market_open?` is the single definition of "the market is open":
+**a weekday, not on the holiday list, between 09:15 and 15:30 IST.** Everything
+that gates on the session reads it — `Orders::PlaceOrderGuard` on the live
+path, `Paper::Exchange` on the simulated one, the MCP status tool, and the
+scanner. It converts the time to IST rather than assuming the caller is already
+there, so it is correct on Render's UTC hosts.
+
+Three layers apply, narrowest first:
+
+| Layer | Window | Applies to |
+|---|---|---|
+| `ConfluenceTrader` entry window | 09:20–15:00 IST, trading days | new entries from the scanner |
+| `MarketCalendar.market_open?` | 09:15–15:30 IST, trading days | every order, from any source |
+| `live:paper_engine` scan loop | 09:15–15:30 IST, trading days | whether the scan runs at all |
+
+So: nothing is entered before 09:20 or after 15:00, nothing at all is placed
+outside 09:15–15:30, and neither happens on a Saturday, a Sunday, or a listed
+market holiday. Outside the session the engine keeps the feed up and reports
+health but makes no REST calls — a reconnect out of hours is cheaper than a
+cold start at 09:15.
+
+The one deliberate exception is a `force: true` order, which waives the
+market-hours check. That is how `Paper::EodSquareOff` closes intraday
+positions at 15:15 and how an operator flattens the book after the bell — a
+square-off that could not run after the close would leave the position it was
+meant to close.
+
+`Paper::Exchange` used to carry its own copy of this check that tested the
+weekday but not the holiday list, so an order placed on a weekday holiday —
+Gandhi Jayanti 2026 is a Friday — was accepted and filled against a stale
+cached price. It now delegates like everything else.
+
 The cooldown and the daily cap are belt and braces over `ConfluenceDetector`'s
 own 45-minute cooldown and state-change gate. That one is keyed on the *signal*
 and lives in `Rails.cache`, so a process restart mid-session repopulates it from

--- a/lib/tasks/live_feed.rake
+++ b/lib/tasks/live_feed.rake
@@ -11,6 +11,7 @@ namespace :live do
 
     subscribe_from_env(hub)
     subscribe_watchlist(hub) if ENV['SUBSCRIBE_WATCHLIST'] == 'true'
+    subscribe_index_watchlist(hub) if ENV['SUBSCRIBE_INDEX_WATCHLIST'] == 'true'
     subscribe_paper_book if Paper::Broker.enabled?
 
     puts "⚡ market feed running (mode=#{mode}, subscriptions=#{hub.subscriptions.size})"
@@ -88,6 +89,111 @@ namespace :live do
     puts "🧹 paper book reset to ₹#{account.initial_capital.to_f.round(2)}"
   end
 
+  desc 'Set the paper book\'s capital (CAPITAL=100000, or PAPER_CAPITAL) and reset it to that figure'
+  task paper_capital: :environment do
+    amount = ENV['CAPITAL'].presence || ENV.fetch('PAPER_CAPITAL', nil)
+    account = PaperAccount.recapitalize!(amount)
+    puts "💰 paper book re-capitalised to ₹#{account.initial_capital.to_f.round(2)} (positions and orders cleared)"
+    pp Paper::Positions.summary
+  end
+
+  desc 'Run the paper-trading engine: market feed + index watchlist scanner in one process'
+  task paper_engine: :environment do
+    guard_paper_engine!
+
+    hub = Live::MarketFeedHub.instance
+    start_token_refresher
+
+    hub.start!(mode: (ENV['MODE'] || 'quote').to_sym)
+    abort('❌ feed failed to start; check credentials and network') unless hub.running?
+
+    subscribe_index_watchlist(hub)
+    subscribe_paper_book
+
+    puts "📄 paper engine up — book ₹#{PaperAccount.current.initial_capital.to_f.round(2)}, " \
+         "watching #{Market::IndexWatchlist.symbols.join(', ')}"
+    puts "   trading=#{Market::IndexWatchlist.trading_enabled?} " \
+         "min_level=#{Market::IndexWatchlist.min_level} " \
+         "scan=#{Market::IndexWatchlist.scan_interval}s " \
+         "cap=#{Market::IndexWatchlist.max_trades_per_day}/symbol/day"
+
+    trap('INT') do
+      puts "\n… stopping paper engine"
+      hub.stop!
+      exit 0
+    end
+
+    run_paper_engine_loop(hub)
+  end
+
+  # The engine places orders on its own initiative, so it refuses to run
+  # anywhere they could reach a broker. PAPER_ENGINE_ALLOW_LIVE is the
+  # deliberate override, and it is not set anywhere in this repo.
+  def guard_paper_engine!
+    return if Paper::Broker.enabled?
+
+    if ENV['PAPER_ENGINE_ALLOW_LIVE'] == 'true'
+      warn('⚠️  paper engine running with PAPER_TRADING off — orders will take the live path')
+      return
+    end
+
+    abort('❌ refusing to run: PAPER_TRADING is not enabled. Set PAPER_TRADING=true, ' \
+          'or PAPER_ENGINE_ALLOW_LIVE=true to run this against the live path on purpose.')
+  end
+
+  # config/initializers/dhan_token_bootstrap.rb and dhan_token_scheduler.rb both
+  # skip when Rake is defined, so that a db:migrate never reaches auth.dhan.co.
+  # A long-lived rake process still needs both, so it does them itself.
+  def start_token_refresher
+    Dhan::TokenManager.current_token!
+    Thread.new do
+      loop do
+        sleep 5.minutes
+        Dhan::TokenManager.current_token!
+      rescue StandardError => e
+        Rails.logger.error("[paper_engine] token refresh failed: #{e.class}: #{e.message}")
+      end
+    end
+  rescue StandardError => e
+    abort("❌ could not mint a Dhan access token: #{e.class}: #{e.message}")
+  end
+
+  # One process holds the feed *and* runs the scan because Live::TickCache is
+  # process-local: a scanner in another process would place orders that no tick
+  # stream ever fills or marks.
+  def run_paper_engine_loop(hub)
+    loop do
+      scan_index_watchlist if paper_engine_session?
+      report_paper_engine_health(hub)
+      sleep Market::IndexWatchlist.scan_interval
+    end
+  end
+
+  def scan_index_watchlist
+    Market::AnalysisUpdater.call
+  rescue StandardError => e
+    Rails.logger.error("[paper_engine] scan failed: #{e.class}: #{e.message}")
+  end
+
+  # 09:15–15:30 IST on a trading day. Outside it the REST calls the scan makes
+  # would return the same stale candles every cycle.
+  def paper_engine_session?
+    now = Time.current.in_time_zone('Asia/Kolkata')
+    return false unless MarketCalendar.trading_day?(now.to_date)
+
+    now.between?(now.change(hour: 9, min: 15), now.change(hour: 15, min: 30))
+  end
+
+  def report_paper_engine_health(hub)
+    health = hub.health
+    summary = Paper::Positions.summary
+    puts "[engine] connected=#{health[:connected]} ticks=#{health[:cached_ticks]} " \
+         "subs=#{health[:tracked_subscriptions]} open=#{summary[:open_positions]} " \
+         "net_pnl=#{summary[:net_pnl]} capital=#{summary[:current_capital]}"
+  rescue StandardError => e
+    Rails.logger.warn("[paper_engine] health snapshot failed: #{e.message}")
+  end
+
   # SYMBOLS=NSE_FNO:49081,IDX_I:13
   def subscribe_from_env(hub)
     ENV['SYMBOLS'].to_s.split(',').each do |pair|
@@ -105,6 +211,17 @@ namespace :live do
     puts "📄 paper book restored: #{count} instrument(s) subscribed"
   rescue StandardError => e
     Rails.logger.warn("[live:feed] could not restore paper-book subscriptions: #{e.message}")
+  end
+
+  # The spot index itself, so the scanner's marks and the option leg's
+  # underlying both tick. Strikes are subscribed by Paper::FeedSubscriber as
+  # they are traded — nobody knows which strike until the signal fires.
+  def subscribe_index_watchlist(hub)
+    subscribed = Market::IndexWatchlist.instruments.count do |instrument|
+      hub.subscribe(segment: instrument.exchange_segment, security_id: instrument.security_id)
+    end
+    puts "📈 index watchlist: #{subscribed} of #{Market::IndexWatchlist.symbols.size} subscribed"
+    subscribed
   end
 
   def subscribe_watchlist(hub)

--- a/lib/tasks/live_feed.rake
+++ b/lib/tasks/live_feed.rake
@@ -175,13 +175,12 @@ namespace :live do
     Rails.logger.error("[paper_engine] scan failed: #{e.class}: #{e.message}")
   end
 
-  # 09:15–15:30 IST on a trading day. Outside it the REST calls the scan makes
-  # would return the same stale candles every cycle.
+  # 09:15–15:30 IST, weekdays, excluding market holidays. Outside it the REST
+  # calls the scan makes would return the same stale candles every cycle. The
+  # feed itself stays up — a reconnect out of hours is cheaper than a cold
+  # start at 09:15.
   def paper_engine_session?
-    now = Time.current.in_time_zone('Asia/Kolkata')
-    return false unless MarketCalendar.trading_day?(now.to_date)
-
-    now.between?(now.change(hour: 9, min: 15), now.change(hour: 15, min: 30))
+    MarketCalendar.market_open?
   end
 
   def report_paper_engine_health(hub)

--- a/render.yaml
+++ b/render.yaml
@@ -82,8 +82,21 @@ services:
         value: "false"
       - key: LIVE_TRADING
         value: "false"
-      # Routes Orders::Gateway to the simulated exchange instead.
+      # Routes Orders::Gateway to the simulated exchange instead. On here so a
+      # TradingView webhook or a Telegram signal hitting the web service books
+      # into the same paper account the engine below trades, rather than being
+      # dropped by the two gates above.
       - key: PAPER_TRADING
+        value: "true"
+      # Starting capital for the simulated book, in rupees. Only applies when
+      # the account row is first created — `rails live:paper_capital` applies a
+      # change to a book that already exists.
+      - key: PAPER_CAPITAL
+        value: "100000"
+      # The web service serves webhooks; it does not scan. The engine worker
+      # owns the scan loop, because Live::TickCache is process-local and Puma
+      # runs WEB_CONCURRENCY forks that would each open their own feed.
+      - key: INDEX_WATCHLIST_TRADING
         value: "false"
 
       # LLM backend. Blank = OpenAI; ollama_cloud uses OLLAMA_API_KEY_1..5.
@@ -106,6 +119,93 @@ services:
       - key: IMPORT_INSTRUMENTS_ON_DEPLOY
         sync: false
       - key: SKIP_SEEDS_ON_DEPLOY
+        sync: false
+
+  # ─────── Paper-trading engine (market feed + index watchlist scanner) ────
+  #
+  # One process, deliberately. `Live::TickCache` is a process-local Hash (see
+  # the instrument-master notes in CLAUDE.md — the measurement behind that
+  # choice), and in paper mode the tick stream is what fills resting orders,
+  # marks positions, and drives Paper::DayRollover / Paper::EodSquareOff. A
+  # scanner in one process and a feed in another would place orders nothing
+  # ever fills. The web service cannot host the feed either: Puma runs
+  # WEB_CONCURRENCY=2 forks and each would open its own WebSocket.
+  #
+  # Every DHAN_* value below is `sync: false`, so set them on this service in
+  # the dashboard as well as on the web service — they are separate services
+  # and do not share environment.
+  - type: worker
+    name: algo_trading_paper_engine
+    runtime: ruby
+    plan: starter
+    buildCommand: "./bin/render-build.sh"
+    startCommand: "bundle exec rake live:paper_engine"
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: AlgoTradingAPI-DB
+          property: connectionString
+      - key: DATABASE_SSLMODE
+        value: require
+      - key: RAILS_ENV
+        value: production
+      # Need not match the web service's — this process serves no cookies and
+      # verifies no signed message; it only has to be present so Rails boots.
+      - key: SECRET_KEY_BASE
+        generateValue: true
+      - key: RAILS_LOG_TO_STDOUT
+        value: "true"
+      # The build script's optional steps are the web service's job.
+      - key: SKIP_SEEDS_ON_DEPLOY
+        value: "true"
+
+      # Simulated book only. `live:paper_engine` aborts on boot unless
+      # PAPER_TRADING is on, because this process places orders on its own
+      # initiative — it must never be one env var away from doing that live.
+      - key: PAPER_TRADING
+        value: "true"
+      - key: PAPER_CAPITAL
+        value: "100000"
+      - key: PLACE_ORDER
+        value: "false"
+      - key: LIVE_TRADING
+        value: "false"
+
+      # The scan loop. INDEX_WATCHLIST_TRADING is what actually lets a
+      # confluence signal become an order; with it off the engine still runs
+      # the feed, the book and the Telegram alerts, and places nothing.
+      - key: INDEX_WATCHLIST
+        value: "NIFTY,BANKNIFTY,SENSEX"
+      - key: INDEX_WATCHLIST_TRADING
+        value: "true"
+      # :high is 8 of 14 confluence factors agreeing. :medium (5) fires several
+      # times a session and is a notification-grade signal, not a trade.
+      - key: INDEX_WATCHLIST_MIN_LEVEL
+        value: "high"
+      - key: INDEX_WATCHLIST_MAX_TRADES_PER_DAY
+        value: "3"
+      - key: INDEX_WATCHLIST_COOLDOWN_MINUTES
+        value: "30"
+      # Matches the 5-minute candles the score is computed on.
+      - key: INDEX_WATCHLIST_SCAN_SECONDS
+        value: "180"
+
+      # Same credentials as the web service, set separately on this one.
+      - key: DHAN_CLIENT_ID
+        sync: false
+      - key: DHAN_API_KEY
+        sync: false
+      - key: DHAN_API_SECRET
+        sync: false
+      - key: DHAN_PIN
+        sync: false
+      - key: DHAN_TOTP_SECRET
+        sync: false
+
+      # Without a chat id the scanner still trades; it just does so silently.
+      - key: TELEGRAM_BOT_TOKEN
+        sync: false
+      - key: TELEGRAM_CHAT_ID
         sync: false
 
   # ─────── Crypto SMC/ICT scanner — NOT DEPLOYED ──────────────────────────

--- a/spec/models/paper_account_spec.rb
+++ b/spec/models/paper_account_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaperAccount do
+  def with_env(vars)
+    stub_const('ENV', ENV.to_h.merge(vars).compact)
+  end
+
+  describe '.configured_capital' do
+    it 'reads PAPER_CAPITAL' do
+      with_env('PAPER_CAPITAL' => '100000')
+
+      expect(described_class.configured_capital).to eq(100_000)
+    end
+
+    it 'accepts the separators a rupee figure gets typed with' do
+      with_env('PAPER_CAPITAL' => '1_00_000')
+      expect(described_class.configured_capital).to eq(100_000)
+
+      with_env('PAPER_CAPITAL' => '2,50,000')
+      expect(described_class.configured_capital).to eq(250_000)
+    end
+
+    it 'falls back to the default when unset' do
+      with_env('PAPER_CAPITAL' => nil)
+
+      expect(described_class.configured_capital).to eq(described_class::DEFAULT_CAPITAL)
+    end
+
+    # A typo must not create a book with zero capital, where every order is
+    # rejected for margin and the run looks like a strategy failure.
+    it 'falls back rather than creating a zero-capital book' do
+      with_env('PAPER_CAPITAL' => 'not a number')
+      expect(described_class.configured_capital).to eq(described_class::DEFAULT_CAPITAL)
+
+      with_env('PAPER_CAPITAL' => '0')
+      expect(described_class.configured_capital).to eq(described_class::DEFAULT_CAPITAL)
+
+      with_env('PAPER_CAPITAL' => '-5000')
+      expect(described_class.configured_capital).to eq(described_class::DEFAULT_CAPITAL)
+    end
+  end
+
+  describe '.current' do
+    it 'creates the book at the configured capital' do
+      with_env('PAPER_CAPITAL' => '100000')
+
+      account = described_class.current
+
+      expect(account.initial_capital).to eq(100_000)
+      expect(account.available_balance).to eq(100_000)
+    end
+
+    # Re-capitalising a running book on every boot would rewrite the
+    # denominator of every P&L figure it has already produced.
+    it 'leaves an existing book alone when the env changes' do
+      with_env('PAPER_CAPITAL' => '100000')
+      described_class.current
+
+      with_env('PAPER_CAPITAL' => '500000')
+
+      expect(described_class.current.initial_capital).to eq(100_000)
+      expect(described_class.count).to eq(1)
+    end
+  end
+
+  describe '.recapitalize!' do
+    it 'sets the capital and resets the book to it' do
+      with_env('PAPER_CAPITAL' => '1000000')
+      account = described_class.current
+      account.update!(available_balance: 250, realized_pnl: -1_500, total_charges: 90, blocked_margin: 400)
+
+      described_class.recapitalize!(100_000)
+
+      expect(account.reload).to have_attributes(
+        initial_capital: 100_000,
+        available_balance: 100_000,
+        blocked_margin: 0,
+        realized_pnl: 0,
+        total_charges: 0
+      )
+      expect(account.reset_at).to be_present
+    end
+
+    it 'defaults to PAPER_CAPITAL when given no argument' do
+      described_class.current
+      with_env('PAPER_CAPITAL' => '100000')
+
+      expect(described_class.recapitalize!.initial_capital).to eq(100_000)
+    end
+
+    it 'refuses a non-positive figure' do
+      described_class.current
+
+      expect { described_class.recapitalize!(0) }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/services/market/confluence_trader_spec.rb
+++ b/spec/services/market/confluence_trader_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Market::ConfluenceTrader do
+  let(:processor) { instance_double(AlertProcessors::Index, call: true) }
+  let!(:nifty) { create(:instrument, :nifty) }
+
+  # A Wednesday inside the entry window. MarketCalendar's holiday list is
+  # checked too, so the date has to be a real trading day.
+  let(:trading_time) { Time.find_zone('Asia/Kolkata').local(2026, 7, 29, 11, 0, 0) }
+
+  def with_env(vars)
+    stub_const('ENV', ENV.to_h.merge(vars).compact)
+  end
+
+  def enabled_env(overrides = {})
+    with_env({
+      'INDEX_WATCHLIST' => 'NIFTY,BANKNIFTY,SENSEX',
+      'INDEX_WATCHLIST_TRADING' => 'true',
+      'INDEX_WATCHLIST_MIN_LEVEL' => 'high'
+    }.merge(overrides))
+  end
+
+  def signal(symbol: 'NIFTY', bias: :bullish, level: :high, net_score: 9)
+    Market::ConfluenceDetector::ConfluenceSignal.new(
+      symbol: symbol, bias: bias, net_score: net_score, max_score: 14, level: level,
+      factors: [Market::ConfluenceDetector::Factor.new(name: 'MACD', value: 1, note: 'Above signal')],
+      close: 24_500.0, atr: 42.5, timestamp: trading_time
+    )
+  end
+
+  before do
+    allow(AlertProcessorFactory).to receive(:build).and_return(processor)
+    travel_to(trading_time)
+  end
+
+  describe 'the gates' do
+    it 'does nothing when INDEX_WATCHLIST_TRADING is off' do
+      enabled_env('INDEX_WATCHLIST_TRADING' => 'false')
+
+      expect(described_class.call(signal: signal)).to be_nil
+      expect(AlertProcessorFactory).not_to have_received(:build)
+      expect(Alert.count).to eq(0)
+    end
+
+    it 'ignores a symbol that is not on the watchlist' do
+      enabled_env('INDEX_WATCHLIST' => 'BANKNIFTY')
+
+      expect(described_class.call(signal: signal(symbol: 'NIFTY'))).to be_nil
+      expect(AlertProcessorFactory).not_to have_received(:build)
+    end
+
+    it 'ignores a signal below the configured conviction' do
+      enabled_env
+
+      expect(described_class.call(signal: signal(level: :medium, net_score: 6))).to be_nil
+      expect(AlertProcessorFactory).not_to have_received(:build)
+    end
+
+    it 'trades a medium signal when the floor is lowered' do
+      enabled_env('INDEX_WATCHLIST_MIN_LEVEL' => 'medium')
+
+      expect(described_class.call(signal: signal(level: :medium, net_score: 6))).to be_a(Alert)
+    end
+
+    # Paper::EodSquareOff closes INTRADAY at 15:15, so a 15:05 entry would be
+    # bought and closed within ten minutes.
+    it 'refuses an entry after the window closes' do
+      enabled_env
+      travel_to(trading_time.change(hour: 15, min: 5))
+
+      expect(described_class.call(signal: signal)).to be_nil
+      expect(AlertProcessorFactory).not_to have_received(:build)
+    end
+
+    it 'refuses an entry before the window opens' do
+      enabled_env
+      travel_to(trading_time.change(hour: 9, min: 16))
+
+      expect(described_class.call(signal: signal)).to be_nil
+    end
+
+    it 'refuses to trade on a non-trading day' do
+      enabled_env
+      travel_to(Time.find_zone('Asia/Kolkata').local(2026, 8, 1, 11, 0, 0)) # Saturday
+
+      expect(described_class.call(signal: signal)).to be_nil
+    end
+
+    it 'skips a symbol the index segment does not carry' do
+      enabled_env('INDEX_WATCHLIST' => 'BANKNIFTY')
+
+      expect(described_class.call(signal: signal(symbol: 'BANKNIFTY'))).to be_nil
+      expect(Alert.count).to eq(0)
+    end
+  end
+
+  describe 'cooldown' do
+    it 'declines a second signal on the same symbol inside the cooldown' do
+      enabled_env('INDEX_WATCHLIST_COOLDOWN_MINUTES' => '30')
+
+      expect(described_class.call(signal: signal)).to be_a(Alert)
+      expect(described_class.call(signal: signal)).to be_nil
+      expect(Alert.count).to eq(1)
+    end
+
+    it 'trades again once the cooldown has expired' do
+      enabled_env('INDEX_WATCHLIST_COOLDOWN_MINUTES' => '30')
+
+      described_class.call(signal: signal)
+      travel_to(trading_time + 31.minutes)
+
+      expect(described_class.call(signal: signal)).to be_a(Alert)
+      expect(Alert.count).to eq(2)
+    end
+
+    it 'cools down per symbol, not globally' do
+      create(:instrument, :nifty, security_id: '25', underlying_symbol: 'BANKNIFTY', symbol_name: 'BANKNIFTY')
+      enabled_env('INDEX_WATCHLIST_COOLDOWN_MINUTES' => '30')
+
+      expect(described_class.call(signal: signal(symbol: 'NIFTY'))).to be_a(Alert)
+      expect(described_class.call(signal: signal(symbol: 'BANKNIFTY'))).to be_a(Alert)
+    end
+  end
+
+  describe 'daily cap' do
+    it 'stops after the configured number of entries for the day' do
+      enabled_env('INDEX_WATCHLIST_MAX_TRADES_PER_DAY' => '2', 'INDEX_WATCHLIST_COOLDOWN_MINUTES' => '1')
+
+      3.times do |i|
+        travel_to(trading_time + (i * 2).minutes)
+        described_class.call(signal: signal)
+      end
+
+      expect(Alert.count).to eq(2)
+    end
+
+    # A skipped alert placed nothing — the processor declined it on its own
+    # analysis — so it must not consume the day's budget.
+    it 'does not count skipped or failed alerts against the cap' do
+      enabled_env('INDEX_WATCHLIST_MAX_TRADES_PER_DAY' => '1', 'INDEX_WATCHLIST_COOLDOWN_MINUTES' => '1')
+
+      described_class.call(signal: signal)
+      Alert.last.update!(status: :skipped)
+      travel_to(trading_time + 2.minutes)
+
+      expect(described_class.call(signal: signal)).to be_a(Alert)
+    end
+  end
+
+  describe 'the alert it builds' do
+    before { enabled_env }
+
+    it 'maps a bullish signal to a call entry on the normal index pipeline' do
+      alert = described_class.call(signal: signal(bias: :bullish))
+
+      expect(alert).to have_attributes(
+        ticker: 'NIFTY',
+        instrument_type: 'index',
+        signal_type: 'long_entry',
+        order_type: 'market',
+        strategy_type: 'intraday',
+        strategy_name: described_class::STRATEGY_NAME,
+        instrument_id: nifty.id
+      )
+      expect(AlertProcessorFactory).to have_received(:build).with(alert)
+      expect(processor).to have_received(:call)
+    end
+
+    it 'maps a bearish signal to a put entry' do
+      alert = described_class.call(signal: signal(bias: :bearish, net_score: -9))
+
+      expect(alert.signal_type).to eq('short_entry')
+    end
+
+    it 'records the score that fired it, so the trade can be explained later' do
+      alert = described_class.call(signal: signal)
+
+      expect(alert.metadata).to include(
+        'triggered_by' => 'index_confluence_scanner',
+        'bias' => 'bullish',
+        'level' => 'high',
+        'net_score' => 9,
+        'max_score' => 14
+      )
+      expect(alert.metadata['factors'].first).to include('name' => 'MACD')
+    end
+
+    it 'carries the close the score was computed on as the alert price' do
+      alert = described_class.call(signal: signal)
+
+      expect(alert.current_price.to_f).to eq(24_500.0)
+    end
+
+    it 'sends SENSEX to BSE' do
+      create(:instrument, :nifty, security_id: '51', underlying_symbol: 'SENSEX',
+                                  symbol_name: 'SENSEX', exchange: 'bse')
+
+      alert = described_class.call(signal: signal(symbol: 'SENSEX'))
+
+      expect(alert.exchange).to eq('BSE')
+    end
+  end
+
+  describe 'failure handling' do
+    before { enabled_env }
+
+    it 'returns nil instead of raising when the processor blows up' do
+      allow(processor).to receive(:call).and_raise(StandardError, 'broker down')
+
+      expect { expect(described_class.call(signal: signal)).to be_nil }.not_to raise_error
+    end
+
+    it 'does nothing with a nil signal' do
+      expect(described_class.call(signal: nil)).to be_nil
+      expect(AlertProcessorFactory).not_to have_received(:build)
+    end
+  end
+end

--- a/spec/services/market/confluence_trader_spec.rb
+++ b/spec/services/market/confluence_trader_spec.rb
@@ -81,10 +81,63 @@ RSpec.describe Market::ConfluenceTrader do
       expect(described_class.call(signal: signal)).to be_nil
     end
 
-    it 'refuses to trade on a non-trading day' do
-      enabled_env
-      travel_to(Time.find_zone('Asia/Kolkata').local(2026, 8, 1, 11, 0, 0)) # Saturday
+    it 'trades exactly on the window boundaries and not a minute outside them' do
+      enabled_env('INDEX_WATCHLIST_COOLDOWN_MINUTES' => '1')
 
+      travel_to(trading_time.change(hour: 9, min: 19))
+      expect(described_class.call(signal: signal)).to be_nil
+
+      travel_to(trading_time.change(hour: 9, min: 20))
+      expect(described_class.call(signal: signal)).to be_a(Alert)
+
+      travel_to(trading_time.change(hour: 15, min: 0))
+      expect(described_class.call(signal: signal)).to be_a(Alert)
+
+      travel_to(trading_time.change(hour: 15, min: 1))
+      expect(described_class.call(signal: signal)).to be_nil
+    end
+
+    it 'never trades outside the session, at any hour of the night' do
+      enabled_env
+
+      [0, 3, 8, 16, 20, 23].each do |hour|
+        travel_to(trading_time.change(hour: hour, min: 30))
+        expect(described_class.call(signal: signal)).to be_nil
+      end
+      expect(Alert.count).to eq(0)
+    end
+
+    it 'refuses to trade at the weekend' do
+      enabled_env
+
+      travel_to(Time.find_zone('Asia/Kolkata').local(2026, 8, 1, 11, 0, 0)) # Saturday
+      expect(described_class.call(signal: signal)).to be_nil
+
+      travel_to(Time.find_zone('Asia/Kolkata').local(2026, 8, 2, 11, 0, 0)) # Sunday
+      expect(described_class.call(signal: signal)).to be_nil
+
+      expect(Alert.count).to eq(0)
+    end
+
+    # A weekday the exchange is shut. The session check has to consult the
+    # holiday list, not just the day of the week.
+    it 'refuses to trade on a weekday market holiday' do
+      enabled_env
+      travel_to(Time.find_zone('Asia/Kolkata').local(2026, 10, 2, 11, 0, 0)) # Gandhi Jayanti, a Friday
+
+      expect(described_class.call(signal: signal)).to be_nil
+      expect(Alert.count).to eq(0)
+    end
+
+    # Render runs UTC. If the window were evaluated in the host's zone, the
+    # scanner would trade the Indian night and sit idle all session.
+    it 'reads the clock in IST even when the host is on UTC' do
+      enabled_env
+
+      travel_to(Time.utc(2026, 7, 29, 6, 30)) # 12:00 IST — inside the window
+      expect(described_class.call(signal: signal)).to be_a(Alert)
+
+      travel_to(Time.utc(2026, 7, 29, 12, 0)) # 17:30 IST — after the close
       expect(described_class.call(signal: signal)).to be_nil
     end
 

--- a/spec/services/market/index_watchlist_spec.rb
+++ b/spec/services/market/index_watchlist_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Market::IndexWatchlist do
+  def with_env(vars)
+    stub_const('ENV', ENV.to_h.merge(vars).compact)
+  end
+
+  describe '.symbols' do
+    it 'defaults to the three indices the app has processors and seeds for' do
+      with_env('INDEX_WATCHLIST' => nil)
+
+      expect(described_class.symbols).to eq(%w[NIFTY BANKNIFTY SENSEX])
+    end
+
+    it 'reads a comma separated list, upcasing and trimming' do
+      with_env('INDEX_WATCHLIST' => ' nifty , FinNifty ')
+
+      expect(described_class.symbols).to eq(%w[NIFTY FINNIFTY])
+    end
+
+    it 'de-duplicates so a repeated symbol is not scanned twice' do
+      with_env('INDEX_WATCHLIST' => 'NIFTY,nifty,SENSEX')
+
+      expect(described_class.symbols).to eq(%w[NIFTY SENSEX])
+    end
+
+    # An empty or whitespace-only value is a misconfiguration, not a request to
+    # watch nothing — falling back keeps the scanner working.
+    it 'falls back to the default when the list is blank' do
+      with_env('INDEX_WATCHLIST' => ' , ')
+
+      expect(described_class.symbols).to eq(%w[NIFTY BANKNIFTY SENSEX])
+    end
+  end
+
+  describe '.exchange_for' do
+    it 'routes the BSE indices to BSE and everything else to NSE' do
+      expect(described_class.exchange_for('SENSEX')).to eq(:bse)
+      expect(described_class.exchange_for('BANKEX')).to eq(:bse)
+      expect(described_class.exchange_for('NIFTY')).to eq(:nse)
+      expect(described_class.exchange_for('SOMETHING_NEW')).to eq(:nse)
+    end
+  end
+
+  describe '.trading_enabled?' do
+    it 'is off unless explicitly switched on' do
+      with_env('INDEX_WATCHLIST_TRADING' => nil)
+
+      expect(described_class).not_to be_trading_enabled
+    end
+
+    it 'is on for "true", case-insensitively' do
+      with_env('INDEX_WATCHLIST_TRADING' => 'TRUE')
+
+      expect(described_class).to be_trading_enabled
+    end
+
+    it 'is off for any other value' do
+      with_env('INDEX_WATCHLIST_TRADING' => '1')
+
+      expect(described_class).not_to be_trading_enabled
+    end
+  end
+
+  describe '.min_level and .level_tradable?' do
+    it 'defaults to high, so a medium signal does not trade' do
+      with_env('INDEX_WATCHLIST_MIN_LEVEL' => nil)
+
+      expect(described_class.min_level).to eq(:high)
+      expect(described_class.level_tradable?(:high)).to be(true)
+      expect(described_class.level_tradable?(:medium)).to be(false)
+    end
+
+    it 'lets medium through when configured' do
+      with_env('INDEX_WATCHLIST_MIN_LEVEL' => 'medium')
+
+      expect(described_class.level_tradable?(:medium)).to be(true)
+      expect(described_class.level_tradable?(:high)).to be(true)
+    end
+
+    it 'ignores a nonsense value rather than trading on everything' do
+      with_env('INDEX_WATCHLIST_MIN_LEVEL' => 'whatever')
+
+      expect(described_class.min_level).to eq(:high)
+    end
+
+    # :none is what the detector returns below its medium threshold. Accepting
+    # it as a floor would trade every non-zero score.
+    it 'refuses :none as a floor' do
+      with_env('INDEX_WATCHLIST_MIN_LEVEL' => 'none')
+
+      expect(described_class.min_level).to eq(:high)
+      expect(described_class.level_tradable?(:none)).to be(false)
+    end
+  end
+
+  describe 'bounds' do
+    it 'clamps the cooldown, the daily cap and the scan interval into sane ranges' do
+      with_env(
+        'INDEX_WATCHLIST_COOLDOWN_MINUTES' => '0',
+        'INDEX_WATCHLIST_MAX_TRADES_PER_DAY' => '9999',
+        'INDEX_WATCHLIST_SCAN_SECONDS' => '1'
+      )
+
+      expect(described_class.cooldown).to eq(1.minute)
+      expect(described_class.max_trades_per_day).to eq(50)
+      expect(described_class.scan_interval).to eq(30)
+    end
+
+    it 'uses the documented defaults when unset' do
+      with_env(
+        'INDEX_WATCHLIST_COOLDOWN_MINUTES' => nil,
+        'INDEX_WATCHLIST_MAX_TRADES_PER_DAY' => nil,
+        'INDEX_WATCHLIST_SCAN_SECONDS' => nil
+      )
+
+      expect(described_class.cooldown).to eq(30.minutes)
+      expect(described_class.max_trades_per_day).to eq(3)
+      expect(described_class.scan_interval).to eq(180)
+    end
+  end
+
+  describe '.instruments' do
+    it 'resolves index-segment instruments and skips symbols the scrip master lacks' do
+      create(:instrument, :nifty)
+      with_env('INDEX_WATCHLIST' => 'NIFTY,NOTLISTED')
+
+      expect(described_class.instruments.map(&:underlying_symbol)).to eq(['NIFTY'])
+    end
+
+    # An equity row with the same symbol must not be mistaken for the index.
+    it 'only looks in the index segment' do
+      create(:instrument, underlying_symbol: 'NIFTY', segment: 'equity')
+      with_env('INDEX_WATCHLIST' => 'NIFTY')
+
+      expect(described_class.instrument_for('NIFTY')).to be_nil
+    end
+  end
+end

--- a/spec/services/market_calendar_spec.rb
+++ b/spec/services/market_calendar_spec.rb
@@ -205,4 +205,47 @@ RSpec.describe MarketCalendar do
       end
     end
   end
+
+  describe '.market_open?' do
+    def ist(date, hour, min)
+      Time.find_zone('Asia/Kolkata').local(date.year, date.month, date.day, hour, min, 0)
+    end
+
+    it 'is open through the weekday session' do
+      expect(described_class.market_open?(ist(wednesday, 9, 15))).to be true
+      expect(described_class.market_open?(ist(wednesday, 12, 0))).to be true
+      expect(described_class.market_open?(ist(wednesday, 15, 30))).to be true
+    end
+
+    it 'is closed before the bell and after it' do
+      expect(described_class.market_open?(ist(wednesday, 9, 14))).to be false
+      expect(described_class.market_open?(ist(wednesday, 8, 0))).to be false
+      expect(described_class.market_open?(ist(wednesday, 15, 31))).to be false
+      expect(described_class.market_open?(ist(wednesday, 22, 0))).to be false
+    end
+
+    it 'is closed all weekend, session hours or not' do
+      expect(described_class.market_open?(ist(saturday, 12, 0))).to be false
+      expect(described_class.market_open?(ist(sunday, 12, 0))).to be false
+    end
+
+    # Holi 2026 falls on a Wednesday — a weekday check alone would call it open.
+    it 'is closed on a weekday market holiday' do
+      expect(holi_2026.on_weekday?).to be true
+      expect(described_class.market_open?(ist(holi_2026, 12, 0))).to be false
+    end
+
+    # Render runs UTC. 12:00 IST is 06:30 UTC, and 06:30 UTC read as a local
+    # time would be outside the session.
+    it 'converts to IST rather than assuming the caller is already there' do
+      utc_noon_ist = Time.utc(wednesday.year, wednesday.month, wednesday.day, 6, 30)
+
+      expect(described_class.market_open?(utc_noon_ist)).to be true
+    end
+
+    it 'defaults to now' do
+      travel_to(ist(wednesday, 12, 0)) { expect(described_class.market_open?).to be true }
+      travel_to(ist(saturday, 12, 0)) { expect(described_class.market_open?).to be false }
+    end
+  end
 end

--- a/spec/services/paper/exchange_spec.rb
+++ b/spec/services/paper/exchange_spec.rb
@@ -208,6 +208,47 @@ RSpec.describe Paper::Exchange do
         expect(described_class.new(account: account).place(buy_market)[:message]).to match(/Market is closed/)
       end
     end
+
+    context 'when market hours are enforced' do
+      before { account.update!(config: account.settings.merge('market_hours_enforced' => true)) }
+
+      def place_at(time)
+        travel_to(time) { described_class.new(account: account).place(buy_market) }
+      end
+
+      it 'accepts an order inside the session' do
+        expect(place_at(Time.zone.parse('2026-07-29 12:00:00'))[:message]).not_to match(/Market is closed/)
+      end
+
+      it 'rejects an order at the weekend' do
+        expect(place_at(Time.zone.parse('2026-08-01 12:00:00'))[:message]).to match(/Market is closed/)
+        expect(place_at(Time.zone.parse('2026-08-02 12:00:00'))[:message]).to match(/Market is closed/)
+      end
+
+      # This is the case a weekday-only check got wrong: Gandhi Jayanti 2026 is
+      # a Friday, so the book accepted orders and filled them against whatever
+      # price was last cached.
+      it 'rejects an order on a weekday market holiday' do
+        expect(place_at(Time.zone.parse('2026-10-02 12:00:00'))[:message]).to match(/Market is closed/)
+      end
+
+      it 'rejects an order before the bell and after the close' do
+        expect(place_at(Time.zone.parse('2026-07-29 09:14:00'))[:message]).to match(/Market is closed/)
+        expect(place_at(Time.zone.parse('2026-07-29 15:31:00'))[:message]).to match(/Market is closed/)
+      end
+
+      # Closing the book has to work after the bell, or an EOD square-off
+      # cannot close the position it was created to close.
+      it 'still lets a forced order through, which is how the square-off works' do
+        result = place_at(Time.zone.parse('2026-07-29 22:00:00'))
+        forced = travel_to(Time.zone.parse('2026-07-29 22:00:00')) do
+          described_class.new(account: account).place(buy_market.merge(force: 'true'))
+        end
+
+        expect(result[:message]).to match(/Market is closed/)
+        expect(forced[:message]).not_to match(/Market is closed/)
+      end
+    end
   end
 
   describe 'super orders' do


### PR DESCRIPTION
The app is signal-driven, so a deployment with nobody pushing TradingView
alerts sits idle no matter what the trading flags say. This adds a third
signal source that runs on its own, and points it at the simulated book.

Market::ConfluenceTrader turns a ConfluenceDetector signal into an Alert and
hands it to AlertProcessorFactory, exactly as the webhook and the Telegram
commands do, so strike selection, affordability, sizing, super-order legs and
exits stay in AlertProcessors::Index -> Orders::Gateway. It is a signal source,
not a second execution path: nothing in it reaches a broker or Paper::Exchange,
and whether the order is simulated stays the gateway's decision.

Market::IndexWatchlist is the roster and the switches. A constant plus
INDEX_WATCHLIST rather than a Watchlist row -- that table is the equity
universe Watchlists::RefreshService rebuilds daily, and three indices that
change about never do not need a migration and a "traded nothing because the
row was missing" failure mode. AnalysisUpdater now reads its symbols from here
too, so analysis and trading cannot drift apart.

live:paper_engine holds the market feed and the scan loop in one process.
Live::TickCache is process-local and in paper mode the tick stream is what
fills resting orders, marks positions and drives DayRollover/EodSquareOff, so a
scanner in another process would place orders nothing ever fills. Puma cannot
host it either: WEB_CONCURRENCY=2 forks would each open their own socket. The
task mints and refreshes the Dhan token itself, because the bootstrap and
scheduler initializers both skip when Rake is defined. It aborts unless
PAPER_TRADING is on -- it places orders on its own initiative and must never be
one env var away from doing that live.

Bounds on the loop, since it runs unattended: a conviction floor
(INDEX_WATCHLIST_MIN_LEVEL, default high = 8 of 14 factors), a per-symbol
cooldown, a per-symbol daily cap, and a 09:20-15:00 IST entry window so nothing
opens inside the 15:15 square-off. The cooldown and cap are keyed on an order
being placed, unlike ConfluenceDetector's own cache-backed cooldown which a
restart repopulates from scratch. A skipped or failed alert does not consume
the daily budget.

PAPER_CAPITAL sets the book's starting capital, read only when the account row
is created -- re-capitalising a running book on every boot would rewrite the
denominator of every P&L figure it has produced. live:paper_capital applies a
change deliberately, clearing the book with it.

render.yaml turns PAPER_TRADING on for the web service so a webhook books into
the same paper account, sets PAPER_CAPITAL=100000, and adds the engine worker
with INDEX_WATCHLIST_TRADING=true. PLACE_ORDER and LIVE_TRADING stay false
everywhere.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015t1pcSunkEuaYZ6ptFhGNq