### PR TITLE
Flush daemon stdout so the paper engine's logs are visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,21 @@ decisions below are settled; each has a failure mode behind it.
   check that accepted orders on market holidays. Don't reintroduce a local
   copy. `force: true` waives it, which is what lets `Paper::EodSquareOff` close
   positions after the bell.
+- **A rake daemon must set `$stdout.sync`.** Ruby block-buffers `$stdout`
+  whenever it is not a TTY, and flushes only at 8 KB or on exit — which a
+  process that runs all session never does. The engine's ~75-byte heartbeat
+  needs ~5.5 hours to fill the buffer, so a healthy worker logged nothing for a
+  whole session and looked like it had never started. Puma sets sync itself, so
+  only the rake workers are exposed. It is set in
+  `config/environments/production.rb` and again in the daemon tasks, because
+  the trap belongs to the process shape rather than the environment. `abort`
+  and `Rails.logger.error` to stderr are unaffected — stderr is never buffered,
+  which is why a crash was always visible and a healthy run was not.
+- **An empty Render log does not mean the worker died.** A service newly
+  declared in `render.yaml` is not created by a push; the blueprint has to be
+  synced from the dashboard first. Until then there is no service to log at
+  all. Check that it exists before debugging its silence — see the
+  troubleshooting order in `docs/PAPER_TRADING_INDICES.md`.
 
 ## LLM layer
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,6 +34,23 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
+  #
+  # `$stdout.sync` must be set before anything writes, and it is not on by
+  # default: Ruby leaves $stdout block-buffered whenever it is not a TTY, which
+  # on Render is always — logs are captured through a pipe. Puma sets sync
+  # itself, so the web service was never affected and this looked like a
+  # non-issue; a `rake` daemon (`live:paper_engine`, `live:feed`) has nothing
+  # that does, so its output sat in an 8 KB buffer that only flushes when the
+  # process exits. A process that runs all session never exits, so a healthy
+  # engine printing a ~75-byte heartbeat every 180s needs ~5.5 hours to fill
+  # the buffer — longer than the 6h15m session — and the dashboard shows an
+  # empty log for a worker that is in fact running fine.
+  #
+  # This covers the logger below and bare `puts` alike, since both write to the
+  # same IO. Do not remove it in favour of setting sync on the logger's device:
+  # `puts` would still be buffered.
+  $stdout.sync = true
+
   config.log_tags = [:request_id]
   config.logger   = ActiveSupport::TaggedLogging.logger($stdout)
 

--- a/docs/PAPER_TRADING_INDICES.md
+++ b/docs/PAPER_TRADING_INDICES.md
@@ -158,6 +158,44 @@ rails live:paper_roll      # force the day rollover
 rails live:paper_reset     # back to starting capital
 ```
 
+## When the engine shows no logs at all
+
+An empty log is ambiguous — it is produced by a worker that never existed, by
+one that crashed before writing, and by one that is running perfectly. Work
+through it in this order rather than assuming the engine is dead.
+
+**1. Does the service exist on Render?** Declaring `algo_trading_paper_engine`
+in `render.yaml` does not create it. A push auto-deploys the services that
+already exist; a service that is new in the blueprint is only created when the
+blueprint is synced from the dashboard (Blueprints → this blueprint → Sync).
+Before the sync there is no worker, no build, and no log stream — the dashboard
+shows nothing, which reads exactly like a service that started and stayed
+quiet. Check the service list before reading anything into an empty log.
+
+**2. Did it abort on boot?** Both abort paths — `PAPER_TRADING` not set, and a
+token that could not be minted — write to stderr, which is never buffered, so
+they appear immediately. Seeing one means the service exists and only its
+environment is wrong. Every `DHAN_*` key is `sync: false` and services do not
+share environment, so the values set on the web service are not visible on the
+worker; missing `DHAN_CLIENT_ID` / `DHAN_PIN` / `DHAN_TOTP_SECRET` make
+`ENV.fetch` raise inside `start_token_refresher` and abort the process.
+
+**3. Is it running but buffered?** This was the original failure. Ruby leaves
+`$stdout` block-buffered whenever it is not a TTY, and on Render logs are
+captured through a pipe. The buffer flushes at 8 KB or on exit, and the engine
+is a daemon that does neither during a session: at a ~75-byte heartbeat every
+180s it needs roughly 5.5 hours to fill 8 KB — longer than the 6h15m session —
+so a healthy engine logged nothing all day. Puma sets sync itself, which is why
+the web service was never affected and this stayed invisible until the first
+rake worker was deployed.
+
+`config/environments/production.rb` and the daemon tasks in
+`lib/tasks/live_feed.rake` now set `$stdout.sync = true`, so a running engine
+prints its `[engine] connected=… ticks=… open=… net_pnl=…` heartbeat every
+`INDEX_WATCHLIST_SCAN_SECONDS`. That line appears outside market hours too —
+the scan is session-gated but the health report is not — so silence during the
+session now means the process really is not running.
+
 ## Turning it off
 
 Set `INDEX_WATCHLIST_TRADING=false` on the engine worker. The feed, the book,

--- a/lib/tasks/live_feed.rake
+++ b/lib/tasks/live_feed.rake
@@ -3,6 +3,7 @@
 namespace :live do
   desc 'Run the market-feed daemon (Live::MarketFeedHub). MODE=ticker|quote|full, SYMBOLS=NSE_FNO:49081,IDX_I:13'
   task feed: :environment do
+    unbuffer_stdout!
     mode = (ENV['MODE'] || 'quote').to_sym
     hub = Live::MarketFeedHub.instance
 
@@ -99,6 +100,7 @@ namespace :live do
 
   desc 'Run the paper-trading engine: market feed + index watchlist scanner in one process'
   task paper_engine: :environment do
+    unbuffer_stdout!
     guard_paper_engine!
 
     hub = Live::MarketFeedHub.instance
@@ -124,6 +126,21 @@ namespace :live do
     end
 
     run_paper_engine_loop(hub)
+  end
+
+  # Ruby leaves $stdout block-buffered whenever it is not a TTY — a pipe to a
+  # log collector, a supervisor, a shell redirect. The buffer only flushes at
+  # 8 KB or on exit, and these tasks are daemons that do neither for a whole
+  # session, so their output is invisible for hours while the process is
+  # perfectly healthy. `bin/ws_feed` has set this since it was written; these
+  # tasks are the same kind of process and need the same line.
+  #
+  # config/environments/production.rb sets this too, so the deployed worker is
+  # covered before the task body runs. It is repeated here because the trap is
+  # a property of the *process shape*, not the environment: the same daemon run
+  # in development under a supervisor buffers identically.
+  def unbuffer_stdout!
+    $stdout.sync = true
   end
 
   # The engine places orders on its own initiative, so it refuses to run

--- a/render.yaml
+++ b/render.yaml
@@ -123,6 +123,23 @@ services:
 
   # ─────── Paper-trading engine (market feed + index watchlist scanner) ────
   #
+  # ⚠ Declaring this service here does not create it. Pushing to the branch
+  # auto-deploys the services that already exist; a service that is new in the
+  # blueprint is only created when the blueprint is synced from the Render
+  # dashboard (Blueprints → this blueprint → Sync). Until that sync happens
+  # there is no worker, no build and no log stream — the dashboard simply shows
+  # nothing for it, which reads exactly like a service that started and stayed
+  # quiet. If this engine appears not to have run for a session, check that the
+  # service exists at all before reading anything into its empty log.
+  #
+  # After the sync, every `sync: false` key below still has to be filled in on
+  # *this* service — services do not share environment, so the DHAN_* values
+  # set on the web service are not visible here. Missing DHAN_CLIENT_ID /
+  # DHAN_PIN / DHAN_TOTP_SECRET make `ENV.fetch` raise inside
+  # `start_token_refresher`, which aborts the process on boot; that abort goes
+  # to stderr and is visible immediately, so a log showing it means the sync
+  # worked and only the variables are missing.
+  #
   # One process, deliberately. `Live::TickCache` is a process-local Hash (see
   # the instrument-master notes in CLAUDE.md — the measurement behind that
   # choice), and in paper mode the tick stream is what fills resting orders,

--- a/spec/lib/tasks/daemon_stdout_buffering_spec.rb
+++ b/spec/lib/tasks/daemon_stdout_buffering_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Guards the unbuffered-stdout lines in config/environments/production.rb and
+# lib/tasks/live_feed.rake.
+#
+# Ruby leaves $stdout block-buffered whenever it is not a TTY, which on Render
+# is always — logs are captured through a pipe. The buffer flushes at 8 KB or
+# on exit, and `live:paper_engine` is a daemon that does neither for a whole
+# trading session. At a ~75-byte heartbeat every 180s it needs ~5.5 hours to
+# fill 8 KB, longer than the 6h15m session, so a perfectly healthy engine
+# showed an empty log all day and looked like it had never started.
+#
+# Puma sets sync itself, so the web service was never affected and this stayed
+# invisible until the first rake worker was deployed. `bin/ws_feed` has carried
+# the line since it was written; the daemon rake tasks did not.
+#
+# These examples exercise the real mechanism in a subprocess rather than
+# asserting on `$stdout.sync` in-process, where RSpec's own reporter has
+# already touched the IO.
+RSpec.describe 'daemon stdout buffering' do
+  # A long-running process in the shape of `live:paper_engine`: it writes a
+  # heartbeat well under 8 KB, then stays alive. Returns whatever a reader can
+  # see while it is still running.
+  def output_visible_while_alive(sync:)
+    script = <<~RUBY
+      $stdout.sync = true if #{sync}
+      require 'logger'
+      Logger.new($stdout).info('[DHAN] paper engine heartbeat')
+      puts '[engine] connected=true ticks=3 subs=3 open=0 net_pnl=0.0'
+      sleep 30
+    RUBY
+
+    read_io, write_io = IO.pipe
+    pid = Process.spawn(RbConfig.ruby, '-e', script, out: write_io, err: File::NULL)
+    write_io.close
+
+    # Give the child time to write and, if it is going to, flush.
+    seen = +''
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 3
+    while Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+      begin
+        seen << read_io.read_nonblock(4096)
+        break
+      rescue IO::WaitReadable
+        IO.select([read_io], nil, nil, 0.1)
+      rescue EOFError
+        break
+      end
+    end
+    seen
+  ensure
+    if pid
+      Process.kill('KILL', pid)
+      Process.wait(pid)
+    end
+    read_io&.close
+  end
+
+  it 'reaches the log collector while the daemon is still running' do
+    expect(output_visible_while_alive(sync: true)).to include('paper engine heartbeat', '[engine] connected=true')
+  end
+
+  # The failure mode itself. If this ever stops holding, Ruby changed its
+  # default and the sync lines are merely redundant rather than load-bearing.
+  it 'is swallowed entirely without the sync line' do
+    expect(output_visible_while_alive(sync: false)).to be_empty
+  end
+
+  describe 'the entry points that need it' do
+    # Read as UTF-8 explicitly: both files carry box-drawing and emoji, and a
+    # host whose default external encoding is not UTF-8 would otherwise fail
+    # these on an encoding error rather than on the thing being asserted.
+    def source(path)
+      File.read(Rails.root.join(path), encoding: 'UTF-8')
+    end
+
+    it 'is set in the production environment, covering the deployed worker' do
+      expect(source('config/environments/production.rb')).to include('$stdout.sync = true')
+    end
+
+    # Repeated in the tasks because the trap is a property of the process
+    # shape, not the environment: the same daemon run in development under a
+    # supervisor buffers identically.
+    it 'is set by both long-running rake daemons' do
+      rakefile = source('lib/tasks/live_feed.rake')
+
+      expect(rakefile).to include('def unbuffer_stdout!', '$stdout.sync = true')
+      expect(rakefile).to match(/task feed: :environment do\s*\n\s*unbuffer_stdout!/)
+      expect(rakefile).to match(/task paper_engine: :environment do\s*\n\s*unbuffer_stdout!/)
+    end
+  end
+end


### PR DESCRIPTION
`live:paper_engine` ran its first session yesterday and produced an empty
log, which read as a worker that never started.

Ruby leaves $stdout block-buffered whenever it is not a TTY, and on Render
logs are captured through a pipe. The buffer flushes at 8 KB or on exit, and
the engine is a daemon that does neither during a session: at a ~75-byte
heartbeat every INDEX_WATCHLIST_SCAN_SECONDS it needs roughly 5.5 hours to
fill 8 KB, longer than the 6h15m session. Puma sets sync itself, so the web
service was never affected and the trap stayed invisible until the first rake
worker was deployed. `bin/ws_feed` has carried the line since it was written;
the daemon rake tasks did not.

Set `$stdout.sync = true` in the production environment, which covers every
deployed process including the worker, and again in `live:feed` and
`live:paper_engine`, because the trap is a property of the process shape
rather than the environment — the same daemon run in development under a
supervisor buffers identically. This covers bare `puts` as well as the
logger, since both write to the same IO.

The specs drive a subprocess in the daemon's shape and assert its output
reaches a reader while it is still alive, with the unsynced case kept as the
control so the guard fails loudly if Ruby ever changes the default.

Also record the other reason this log was empty: declaring
algo_trading_paper_engine in render.yaml does not create it. A push
auto-deploys existing services, while a service that is new in the blueprint
is created only when the blueprint is synced from the dashboard — until then
there is no service to log at all. Documented in render.yaml, CLAUDE.md and a
troubleshooting order in docs/PAPER_TRADING_INDICES.md, since an empty log is
produced by a worker that never existed, one that crashed, and one that is
running perfectly, and those need telling apart.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GtufxPCWLATbo1tEncbEmg