### PR TITLE
Add TOKEN_PROVIDER_ONLY gate for a trading-free deployment mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  # Set TOKEN_PROVIDER_ONLY=true to run this deployment as a bare Dhan token
+  # provider: every controller except Auth::DhanController (token issuance,
+  # login/callback) is shut off. Dhan::TokenManager's boot-time refresh and
+  # background refresh thread (config/initializers/dhan_token_bootstrap.rb,
+  # dhan_token_scheduler.rb) are untouched by this flag and keep running so the
+  # token stays fresh for callers.
+  TOKEN_PROVIDER_ALLOWED_CONTROLLERS = %w[Auth::DhanController].freeze
+
+  before_action :enforce_token_provider_mode
+
   rescue_from StandardError, with: :handle_internal_error
 
   rescue_from ActiveRecord::RecordNotFound do |e|
@@ -8,6 +18,14 @@ class ApplicationController < ActionController::API
   end
 
   private
+
+  def enforce_token_provider_mode
+    return unless ENV['TOKEN_PROVIDER_ONLY'] == 'true'
+    return if TOKEN_PROVIDER_ALLOWED_CONTROLLERS.include?(self.class.name)
+
+    render json: { error: 'This instance runs in token-provider-only mode; trading endpoints are disabled.' },
+           status: :service_unavailable
+  end
 
   def handle_internal_error(exception)
     ErrorLogger.log_error('Internal server error', exception)

--- a/app/controllers/auth/dhan_controller.rb
+++ b/app/controllers/auth/dhan_controller.rb
@@ -5,8 +5,22 @@ module Auth
   class DhanController < ApplicationController
     include ActionController::HttpAuthentication::Basic::ControllerMethods
 
+    DASHBOARD_REALM = 'Dhan Token Status'
+    MAX_AUTH_FAILURES = 10
+    AUTH_LOCKOUT_WINDOW = 5.minutes
+
+    # login/callback are the OAuth-style hand-off with Dhan and would otherwise be
+    # public, unauthenticated GETs — anyone could hit /login to mint a consent
+    # session with our app_id/app_secret, complete it with their own Dhan account,
+    # and let Dhan's redirect land a foreign access_token in our single-row store,
+    # silently hijacking the token every other caller then receives. Gating both
+    # behind the same Basic Auth as /status closes that: an attacker without the
+    # shared secret can't start the flow, and a browser that already authenticated
+    # for /login reuses the cached credentials automatically when Dhan redirects
+    # back to /callback (same origin, same realm).
+    before_action :apply_security_headers
+    before_action :authenticate_dashboard_request, only: %i[login callback status]
     before_action :authenticate_token_request, only: :token
-    before_action :authenticate_status_request, only: :status
 
     # STEP 1 + redirect to STEP 2: generate consent, send user to Dhan login.
     def login
@@ -68,7 +82,17 @@ module Auth
 
     private
 
+    def apply_security_headers
+      response.set_header('Cache-Control', 'no-store')
+      response.set_header('X-Content-Type-Options', 'nosniff')
+      response.set_header('X-Frame-Options', 'DENY')
+      response.set_header('Referrer-Policy', 'no-referrer')
+      response.set_header('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'")
+    end
+
     def authenticate_token_request
+      return if rate_limited?(:token, as: :json)
+
       expected = Auth::DhanTokenEndpointSecret.configured_secret
       if expected.blank?
         render json: { error: token_endpoint_config_error }, status: :service_unavailable
@@ -76,21 +100,74 @@ module Auth
       end
 
       bearer = request.authorization.to_s.sub(/\ABearer\s+/i, '').strip
-      return if ActiveSupport::SecurityUtils.secure_compare(bearer, expected)
+      if ActiveSupport::SecurityUtils.secure_compare(bearer, expected)
+        reset_auth_failures(:token)
+        return
+      end
 
+      register_auth_failure(:token)
       render json: { error: 'Invalid or missing Authorization: Bearer token' }, status: :unauthorized
     end
 
-    def authenticate_status_request
+    def authenticate_dashboard_request
+      return if rate_limited?(:dashboard, as: :plain)
+
       expected = Auth::DhanTokenEndpointSecret.configured_secret
       if expected.blank?
         render plain: token_endpoint_config_error, status: :service_unavailable
         return
       end
 
-      authenticate_or_request_with_http_basic('Dhan Token Status') do |_user, password|
-        ActiveSupport::SecurityUtils.secure_compare(password, expected)
+      authenticate_or_request_with_http_basic(DASHBOARD_REALM) do |_user, password|
+        ok = ActiveSupport::SecurityUtils.secure_compare(password, expected)
+        ok ? reset_auth_failures(:dashboard) : register_auth_failure(:dashboard)
+        ok
       end
+    end
+
+    # Per-IP failure lockout for both auth paths. Rails.cache is process-local
+    # memory_store in production (see config/environments/production.rb), so with
+    # WEB_CONCURRENCY=2 the effective ceiling is up to 2x MAX_AUTH_FAILURES across
+    # workers — an acceptable trade for not adding a shared-store dependency just
+    # for this.
+    def rate_limited?(bucket, as:)
+      return false if auth_failure_count(bucket) < MAX_AUTH_FAILURES
+
+      message = 'Too many failed attempts. Try again later.'
+      if as == :json
+        render json: { error: message }, status: :too_many_requests
+      else
+        render plain: message, status: :too_many_requests
+      end
+      true
+    end
+
+    def auth_failure_count(bucket)
+      Rails.cache.read(auth_lockout_key(bucket)).to_i
+    end
+
+    def register_auth_failure(bucket)
+      count = Rails.cache.increment(auth_lockout_key(bucket), 1, expires_in: AUTH_LOCKOUT_WINDOW)
+      notify_auth_lockout(bucket) if count == MAX_AUTH_FAILURES
+    end
+
+    def reset_auth_failures(bucket)
+      Rails.cache.delete(auth_lockout_key(bucket))
+    end
+
+    def auth_lockout_key(bucket)
+      "dhan_auth_lockout:#{bucket}:#{request.remote_ip}"
+    end
+
+    def notify_auth_lockout(bucket)
+      return if ENV['TELEGRAM_BOT_TOKEN'].blank? || ENV['TELEGRAM_CHAT_ID'].blank?
+
+      TelegramNotifier.send_message(
+        "🚨 #{MAX_AUTH_FAILURES} failed Dhan #{bucket} auth attempts from #{request.remote_ip}. " \
+        "Locked out for #{AUTH_LOCKOUT_WINDOW.inspect}."
+      )
+    rescue StandardError => e
+      Rails.logger.warn("[Auth::DhanController] lockout notify failed: #{e.message}")
     end
 
     def status_html(record)

--- a/app/controllers/auth/dhan_controller.rb
+++ b/app/controllers/auth/dhan_controller.rb
@@ -3,7 +3,10 @@
 module Auth
   # Handles Dhan OAuth-style consent flow and token endpoint for API access.
   class DhanController < ApplicationController
+    include ActionController::HttpAuthentication::Basic::ControllerMethods
+
     before_action :authenticate_token_request, only: :token
+    before_action :authenticate_status_request, only: :status
 
     # STEP 1 + redirect to STEP 2: generate consent, send user to Dhan login.
     def login
@@ -38,6 +41,13 @@ module Auth
       render json: { error: 'Token unavailable. Re-login at /auth/dhan/login' }, status: :service_unavailable
     end
 
+    # Browser-facing dashboard: same facts as GET /token, rendered as HTML behind
+    # HTTP Basic Auth (so a browser prompts for credentials natively instead of
+    # requiring a Bearer header). Never renders the full access token.
+    def status
+      render plain: status_html(DhanAccessToken.current_record), content_type: 'text/html'
+    end
+
     # STEP 3: Dhan redirects here with tokenId; exchange for access token and store.
     def callback
       token_id = params[:tokenId]
@@ -69,6 +79,75 @@ module Auth
       return if ActiveSupport::SecurityUtils.secure_compare(bearer, expected)
 
       render json: { error: 'Invalid or missing Authorization: Bearer token' }, status: :unauthorized
+    end
+
+    def authenticate_status_request
+      expected = Auth::DhanTokenEndpointSecret.configured_secret
+      if expected.blank?
+        render plain: token_endpoint_config_error, status: :service_unavailable
+        return
+      end
+
+      authenticate_or_request_with_http_basic('Dhan Token Status') do |_user, password|
+        ActiveSupport::SecurityUtils.secure_compare(password, expected)
+      end
+    end
+
+    def status_html(record)
+      remaining_minutes = record ? ((record.expires_at - Time.current) / 60).round : nil
+      state = if record.nil?
+                'missing'
+              else
+                remaining_minutes.positive? ? 'active' : 'expired'
+              end
+
+      rows = {
+        'Status' => %(<span class="badge #{state}">#{state.upcase}</span>),
+        'Token' => "<code>#{h(mask_token(record&.access_token))}</code>",
+        'Expires at' => record ? "#{h(record.expires_at.iso8601)} (#{remaining_minutes} min remaining)" : '—',
+        'Last refreshed' => record ? h(record.created_at.iso8601) : '—',
+        'Client ID' => h(dhan_client_id),
+        'Mode' => ENV['TOKEN_PROVIDER_ONLY'] == 'true' ? 'Token provider only' : 'Trading enabled'
+      }
+
+      <<~HTML
+        <!doctype html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+          <title>Dhan Token Status</title>
+          <style>
+            body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 640px; margin: 3rem auto; padding: 0 1rem; color: #1a1a1a; }
+            h1 { font-size: 1.25rem; }
+            table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+            td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #e2e2e2; vertical-align: top; }
+            td:first-child { color: #666; width: 40%; }
+            .badge { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 999px; font-size: 0.85rem; font-weight: 600; }
+            .active { background: #dcfce7; color: #166534; }
+            .expired, .missing { background: #fee2e2; color: #991b1b; }
+            .meta { color: #888; font-size: 0.8rem; margin-top: 2rem; }
+          </style>
+        </head>
+        <body>
+          <h1>Dhan Access Token</h1>
+          <table>
+            #{rows.map { |k, v| "<tr><td>#{h(k)}</td><td>#{v}</td></tr>" }.join}
+          </table>
+          <p class="meta">Rendered at #{h(Time.current.iso8601)}</p>
+        </body>
+        </html>
+      HTML
+    end
+
+    def mask_token(token)
+      return '—' if token.blank?
+      return token if token.length <= 12
+
+      "#{token[0..7]}…#{token[-4..]}"
+    end
+
+    def h(text)
+      CGI.escapeHTML(text.to_s)
     end
 
     def token_endpoint_config_error

--- a/config/initializers/crypto_smc_scanner.rb
+++ b/config/initializers/crypto_smc_scanner.rb
@@ -21,6 +21,7 @@
 #     inert on every existing deployment.
 Rails.application.config.after_initialize do
   next unless ENV.fetch('CRYPTO_SMC_AUTOSTART', 'false').to_s.downcase == 'true'
+  next if ENV['TOKEN_PROVIDER_ONLY'] == 'true'
   next unless Crypto::Config.enabled?
   next if Rails.env.test?
   # Rake tasks, migrations and consoles have no business holding a socket open.

--- a/config/initializers/ta_scheduler.rb
+++ b/config/initializers/ta_scheduler.rb
@@ -1,7 +1,7 @@
 START_TIME = Time.zone.parse('09:10')
 END_TIME = Time.zone.parse('15:30')
 
-if ENV['ENABLE_TA_LOOP'] == 'true'
+if ENV['ENABLE_TA_LOOP'] == 'true' && ENV['TOKEN_PROVIDER_ONLY'] != 'true'
   Rails.application.config.after_initialize do
     next if defined?(Rake) # skip during db:migrate, db:seed, and other one-off rake tasks
     next unless ActiveRecord::Base.connection.table_exists?('dhan_access_tokens')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     get 'dhan/login', to: 'dhan#login', as: :dhan_login
     get 'dhan/callback', to: 'dhan#callback', as: :dhan_callback
     get 'dhan/token', to: 'dhan#token', as: :dhan_token
+    get 'dhan/status', to: 'dhan#status', as: :dhan_status
   end
 
   resources :swing_picks

--- a/docs/DHAN_AUTH.md
+++ b/docs/DHAN_AUTH.md
@@ -4,10 +4,12 @@ Dhan uses an **API Key & Secret** flow (auth.dhan.co): the access token is user-
 
 ## Flow (3 steps)
 
-1. **Login** — Visit `GET /auth/dhan/login`. The app calls Dhan to generate a consent session, then redirects you to **auth.dhan.co** to log in and approve.
-2. **Callback** — After login, Dhan redirects to `GET /auth/dhan/callback?tokenId=...`. The app exchanges the tokenId for an access token and stores it in `dhan_access_tokens`.
+1. **Login** — Visit `GET /auth/dhan/login`. Your browser will prompt for HTTP Basic credentials first (see below) — any username, and the same secret used for `/auth/dhan/token` as the password. Once authenticated, the app calls Dhan to generate a consent session and redirects you to **auth.dhan.co** to log in and approve.
+2. **Callback** — After login, Dhan redirects to `GET /auth/dhan/callback?tokenId=...`. This route requires the same Basic Auth as `/login`; your browser reuses the credentials it already cached for this origin, so you normally aren't re-prompted. The app exchanges the tokenId for an access token and stores it in `dhan_access_tokens`.
 3. **Usage** — The DhanHQ client reads the token from the DB (injected in `config/initializers/dhanhq.rb`). No manual copy-paste.
 4. **Expiry** — When the token expires, trading jobs halt. Re-login at `/auth/dhan/login`.
+
+`/login` and `/callback` are gated deliberately: left open, anyone could hit `/login` to mint a consent session under your `DHAN_API_KEY`/`DHAN_API_SECRET`, approve it with *their own* Dhan account, and let Dhan's redirect overwrite `dhan_access_tokens` with a foreign token — silently hijacking every token every other caller then receives. Requiring the shared secret up front closes that off.
 
 ## Environment
 
@@ -36,6 +38,18 @@ Example:
 ```bash
 curl -H "Authorization: Bearer YOUR_DHAN_TOKEN_ACCESS_TOKEN" https://algo-trading-api.onrender.com/auth/dhan/token
 ```
+
+## Browser dashboard
+
+`GET /auth/dhan/status` is a small read-only HTML page — token state, expiry countdown, last-refresh time, masked token (never the full value) — for checking things by eye instead of `curl`. It's gated behind HTTP Basic Auth using the same secret as `/token`; the browser will prompt for credentials the first time.
+
+## Security notes
+
+- **Same secret, three doors.** `DHAN_TOKEN_ACCESS_TOKEN` (or the `dhan.token_endpoint_secret` credential) gates `/token` (Bearer), and `/login` + `/callback` + `/status` (Basic). Rotate it by changing that one value; nothing else references it.
+- **Lockout on repeated failures.** After 10 failed auth attempts from the same IP within 5 minutes, that IP is locked out (`429`) for the rest of the window — including with the *correct* secret, so don't hammer a misconfigured integration or you'll lock yourself out too. A Telegram alert fires once per lockout if `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` are set.
+- **Nothing sensitive is cached.** Every response from this controller sets `Cache-Control: no-store`, and `/status` adds `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and a `default-src 'none'` CSP, so the page can't be framed, sniffed, or cached by a shared proxy.
+- **The full access token is only ever in the `/token` JSON response**, never in `/status`'s HTML (which shows a masked `prefix…suffix` instead) or in any log line (`filter_parameter_logging.rb` also redacts anything matching `token`/`secret`/`_key` as a backstop).
+- **Transport is enforced.** `config.force_ssl = true` in production, so Basic Auth credentials and Bearer tokens never travel over plain HTTP.
 
 ## Jobs
 

--- a/render.yaml
+++ b/render.yaml
@@ -99,6 +99,17 @@ services:
       - key: INDEX_WATCHLIST_TRADING
         value: "false"
 
+      # Set to "true" to run this deployment as a bare Dhan token provider:
+      # ApplicationController 503s every route except /auth/dhan/*, so other
+      # apps/bots can call GET /auth/dhan/token for an always-fresh access
+      # token without this instance placing a single order. TokenManager's
+      # boot-time refresh and the 5-minute background refresh thread are
+      # unaffected and keep the token current either way. If you flip this on,
+      # also suspend (or never sync) the algo_trading_paper_engine worker
+      # below — it places orders on its own initiative and has no use here.
+      - key: TOKEN_PROVIDER_ONLY
+        value: "false"
+
       # LLM backend. Blank = OpenAI; ollama_cloud uses OLLAMA_API_KEY_1..5.
       - key: LLM_BACKEND
         sync: false

--- a/spec/requests/auth/dhan_spec.rb
+++ b/spec/requests/auth/dhan_spec.rb
@@ -157,4 +157,49 @@ RSpec.describe 'Auth::Dhan' do
       end
     end
   end
+
+  describe 'GET /auth/dhan/status', :no_dhan_token do
+    let(:secret) { 'token-api-secret-at-least-24-chars' }
+
+    before do
+      allow(Auth::DhanTokenEndpointSecret).to receive(:configured_secret).and_return(secret)
+    end
+
+    it 'returns 401 without credentials' do
+      get auth_dhan_status_url
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 401 with wrong password' do
+      get auth_dhan_status_url, headers: { 'Authorization' => basic_auth_header('anything', 'wrong') }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'renders an HTML page with masked token when a token exists' do
+      DhanAccessToken.delete_all
+      DhanAccessToken.create!(access_token: 'eyJhbGciOiJIUzI1NiJ9.testtoken.signature', expires_at: 30.minutes.from_now)
+
+      get auth_dhan_status_url, headers: { 'Authorization' => basic_auth_header('anything', secret) }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include('text/html')
+      expect(response.body).to include('ACTIVE')
+      expect(response.body).not_to include('eyJhbGciOiJIUzI1NiJ9.testtoken.signature')
+    end
+
+    it 'renders MISSING when no token exists' do
+      DhanAccessToken.delete_all
+
+      get auth_dhan_status_url, headers: { 'Authorization' => basic_auth_header('anything', secret) }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('MISSING')
+    end
+  end
+
+  def basic_auth_header(user, password)
+    "Basic #{Base64.strict_encode64("#{user}:#{password}")}"
+  end
 end

--- a/spec/requests/auth/dhan_spec.rb
+++ b/spec/requests/auth/dhan_spec.rb
@@ -3,11 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe 'Auth::Dhan' do
-  describe 'GET /auth/dhan/login' do
+  let(:dashboard_secret) { 'token-api-secret-at-least-24-chars' }
+
+  def basic_auth_header(user, password)
+    "Basic #{Base64.strict_encode64("#{user}:#{password}")}"
+  end
+
+  describe 'GET /auth/dhan/login', :no_dhan_token do
     let(:consent_url) { %r{https://auth\.dhan\.co/app/generate-consent\?client_id=client-123} }
     let(:consent_response) { { consentAppId: 'consent-abc', consentAppStatus: 'GENERATED', status: 'success' }.to_json }
 
     before do
+      allow(Auth::DhanTokenEndpointSecret).to receive(:configured_secret).and_return(dashboard_secret)
       stub_request(:post, consent_url)
         .with(headers: { 'app_id' => 'api-key', 'app_secret' => 'api-secret' })
         .to_return(status: 200, body: consent_response, headers: { 'Content-Type' => 'application/json' })
@@ -18,8 +25,15 @@ RSpec.describe 'Auth::Dhan' do
       allow(ENV).to receive(:fetch).with('DHAN_API_SECRET', nil).and_return('api-secret')
     end
 
-    it 'generates consent and redirects to Dhan login with consentAppId' do
+    it 'returns 401 without credentials, without calling Dhan' do
       get auth_dhan_login_url
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(a_request(:post, consent_url)).not_to have_been_made
+    end
+
+    it 'generates consent and redirects to Dhan login with consentAppId when authenticated' do
+      get auth_dhan_login_url, headers: { 'Authorization' => basic_auth_header('anything', dashboard_secret) }
 
       expect(response).to have_http_status(:redirect)
       expect(response.location).to start_with('https://auth.dhan.co/login/consentApp-login?')
@@ -27,8 +41,20 @@ RSpec.describe 'Auth::Dhan' do
     end
   end
 
-  describe 'GET /auth/dhan/callback' do
+  describe 'GET /auth/dhan/callback', :no_dhan_token do
     let(:consume_url) { %r{https://auth\.dhan\.co/app/consumeApp-consent\?tokenId=token-xyz} }
+    let(:auth_header) { { 'Authorization' => basic_auth_header('anything', dashboard_secret) } }
+
+    before do
+      allow(Auth::DhanTokenEndpointSecret).to receive(:configured_secret).and_return(dashboard_secret)
+    end
+
+    it 'returns 401 without credentials and does not create a token' do
+      expect { get auth_dhan_callback_url(tokenId: 'token-xyz') }
+        .not_to change(DhanAccessToken, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
 
     context 'when consent consume succeeds' do
       before do
@@ -48,7 +74,7 @@ RSpec.describe 'Auth::Dhan' do
       end
 
       it 'creates a DhanAccessToken and returns success' do
-        expect { get auth_dhan_callback_url(tokenId: 'token-xyz') }
+        expect { get auth_dhan_callback_url(tokenId: 'token-xyz'), headers: auth_header }
           .to change(DhanAccessToken, :count).by(1)
 
         expect(response).to have_http_status(:ok)
@@ -62,7 +88,7 @@ RSpec.describe 'Auth::Dhan' do
 
     context 'when tokenId is missing' do
       it 'returns unprocessable_entity and does not create a token' do
-        expect { get auth_dhan_callback_url }
+        expect { get auth_dhan_callback_url, headers: auth_header }
           .not_to change(DhanAccessToken, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)
@@ -81,7 +107,7 @@ RSpec.describe 'Auth::Dhan' do
       end
 
       it 'returns unprocessable_entity and does not create a token' do
-        expect { get auth_dhan_callback_url(tokenId: 'token-xyz') }
+        expect { get auth_dhan_callback_url(tokenId: 'token-xyz'), headers: auth_header }
           .not_to change(DhanAccessToken, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)
@@ -91,7 +117,7 @@ RSpec.describe 'Auth::Dhan' do
   end
 
   describe 'GET /auth/dhan/token', :no_dhan_token do
-    let(:secret) { 'token-api-secret-at-least-24-chars' }
+    let(:secret) { dashboard_secret }
 
     context 'when token endpoint secret is not configured' do
       before { allow(Auth::DhanTokenEndpointSecret).to receive(:configured_secret).and_return(nil) }
@@ -155,11 +181,22 @@ RSpec.describe 'Auth::Dhan' do
         expect(body['client_id']).to eq('client-456')
         expect(body['expires_at']).to be_present
       end
+
+      it 'sets Cache-Control: no-store and hardening headers' do
+        DhanAccessToken.delete_all
+        DhanAccessToken.create!(access_token: 'jwt.here', expires_at: 1.hour.from_now)
+
+        get auth_dhan_token_url, headers: { 'Authorization' => "Bearer #{secret}" }
+
+        expect(response.headers['Cache-Control']).to eq('no-store')
+        expect(response.headers['X-Content-Type-Options']).to eq('nosniff')
+        expect(response.headers['X-Frame-Options']).to eq('DENY')
+      end
     end
   end
 
   describe 'GET /auth/dhan/status', :no_dhan_token do
-    let(:secret) { 'token-api-secret-at-least-24-chars' }
+    let(:secret) { dashboard_secret }
 
     before do
       allow(Auth::DhanTokenEndpointSecret).to receive(:configured_secret).and_return(secret)
@@ -197,9 +234,62 @@ RSpec.describe 'Auth::Dhan' do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('MISSING')
     end
+
+    it 'sets Cache-Control: no-store and a restrictive CSP' do
+      get auth_dhan_status_url, headers: { 'Authorization' => basic_auth_header('anything', secret) }
+
+      expect(response.headers['Cache-Control']).to eq('no-store')
+      expect(response.headers['Content-Security-Policy']).to include("default-src 'none'")
+    end
   end
 
-  def basic_auth_header(user, password)
-    "Basic #{Base64.strict_encode64("#{user}:#{password}")}"
+  describe 'auth failure lockout', :no_dhan_token do
+    around do |example|
+      original_cache = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      example.run
+    ensure
+      Rails.cache = original_cache
+    end
+
+    before do
+      allow(Auth::DhanTokenEndpointSecret).to receive(:configured_secret).and_return(dashboard_secret)
+    end
+
+    it 'locks out the Bearer token endpoint after repeated failures from the same IP' do
+      10.times do
+        get auth_dhan_token_url, headers: { 'Authorization' => 'Bearer wrong' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      get auth_dhan_token_url, headers: { 'Authorization' => "Bearer #{dashboard_secret}" }
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it 'resets the lockout counter on a successful Bearer auth' do
+      3.times { get auth_dhan_token_url, headers: { 'Authorization' => 'Bearer wrong' } }
+
+      DhanAccessToken.delete_all
+      DhanAccessToken.create!(access_token: 'jwt.here', expires_at: 1.hour.from_now)
+      get auth_dhan_token_url, headers: { 'Authorization' => "Bearer #{dashboard_secret}" }
+      expect(response).to have_http_status(:ok)
+
+      9.times do
+        get auth_dhan_token_url, headers: { 'Authorization' => 'Bearer wrong' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it 'locks out the dashboard (Basic Auth) endpoints after repeated failures from the same IP' do
+      10.times do
+        get auth_dhan_status_url, headers: { 'Authorization' => basic_auth_header('x', 'wrong') }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      get auth_dhan_status_url, headers: { 'Authorization' => basic_auth_header('x', dashboard_secret) }
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
   end
 end

--- a/spec/requests/token_provider_mode_spec.rb
+++ b/spec/requests/token_provider_mode_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'TOKEN_PROVIDER_ONLY mode', :no_dhan_token do
+  around do |example|
+    original = ENV.fetch('TOKEN_PROVIDER_ONLY', nil)
+    example.run
+  ensure
+    ENV['TOKEN_PROVIDER_ONLY'] = original
+  end
+
+  context 'when disabled (default)' do
+    before { ENV['TOKEN_PROVIDER_ONLY'] = nil }
+
+    it 'serves trading routes normally' do
+      get funds_url
+
+      expect(response).not_to have_http_status(:service_unavailable)
+    end
+  end
+
+  context 'when enabled' do
+    before { ENV['TOKEN_PROVIDER_ONLY'] = 'true' }
+
+    it 'shuts off trading routes' do
+      get funds_url
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.parsed_body['error']).to include('token-provider-only mode')
+    end
+
+    it 'still serves the Dhan token endpoint' do
+      secret = 'token-api-secret-at-least-24-chars'
+      allow(Auth::DhanTokenEndpointSecret).to receive(:configured_secret).and_return(secret)
+      DhanAccessToken.delete_all
+      DhanAccessToken.create!(access_token: 'jwt.here', expires_at: 1.hour.from_now)
+
+      get auth_dhan_token_url, headers: { 'Authorization' => "Bearer #{secret}" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['access_token']).to eq('jwt.here')
+    end
+
+    it 'still serves the Dhan login route' do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('DHAN_CLIENT_ID', nil).and_return('client-123')
+      allow(ENV).to receive(:fetch).with('CLIENT_ID', nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with('DHAN_API_KEY', nil).and_return('api-key')
+      allow(ENV).to receive(:fetch).with('DHAN_API_SECRET', nil).and_return('api-secret')
+      stub_request(:post, %r{https://auth\.dhan\.co/app/generate-consent})
+        .to_return(status: 200, body: { consentAppId: 'abc', status: 'success' }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+
+      get auth_dhan_login_url
+
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/requests/token_provider_mode_spec.rb
+++ b/spec/requests/token_provider_mode_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe 'TOKEN_PROVIDER_ONLY mode', :no_dhan_token do
     end
 
     it 'still serves the Dhan login route' do
+      secret = 'token-api-secret-at-least-24-chars'
+      allow(Auth::DhanTokenEndpointSecret).to receive(:configured_secret).and_return(secret)
       allow(ENV).to receive(:fetch).and_call_original
       allow(ENV).to receive(:fetch).with('DHAN_CLIENT_ID', nil).and_return('client-123')
       allow(ENV).to receive(:fetch).with('CLIENT_ID', nil).and_return(nil)
@@ -52,7 +54,8 @@ RSpec.describe 'TOKEN_PROVIDER_ONLY mode', :no_dhan_token do
         .to_return(status: 200, body: { consentAppId: 'abc', status: 'success' }.to_json,
                    headers: { 'Content-Type' => 'application/json' })
 
-      get auth_dhan_login_url
+      basic = "Basic #{Base64.strict_encode64("anything:#{secret}")}"
+      get auth_dhan_login_url, headers: { 'Authorization' => basic }
 
       expect(response).to have_http_status(:redirect)
     end


### PR DESCRIPTION
Lets this instance run as a bare Dhan token provider: ApplicationController
503s every route except Auth::DhanController when TOKEN_PROVIDER_ONLY=true,
while Dhan::TokenManager's boot-time and 5-minute background refresh keep
running unaffected, so other apps/bots can hit GET /auth/dhan/token for an
always-fresh access token without this instance placing any orders. The
opt-in TA loop and crypto SMC autostart threads are also gated as
defense-in-depth so a stray env var can't start them on a token-provider
instance.